### PR TITLE
Load subr-x for using if-let

### DIFF
--- a/loopy.el
+++ b/loopy.el
@@ -40,6 +40,7 @@
 (require 'cl-lib)
 (require 'pcase)
 (require 'seq)
+(require 'subr-x)
 
 ;;;; Important Variables
 ;; These are only ever set locally.


### PR DESCRIPTION
This patch fixes following byte-compile warnings.

```
In loopy--parse-body-forms:
loopy.el:196:49:Warning: ‘(command-parser (loopy--get-custom-command-parser
    form))’ is a malformed function
loopy.el:196:49:Warning: ‘(custom-instructions (funcall command-parser form))’
    is a malformed function
loopy.el:441:71:Warning: ‘(command-parser (loopy--get-custom-command-parser
    form))’ is a malformed function
loopy.el:441:71:Warning: ‘(custom-instructions (funcall command-parser form))’
    is a malformed function
loopy.el:443:44:Warning: reference to free variable ‘custom-instructions’
loopy.el:445:25:Warning: reference to free variable ‘command-parser’

In end of data:
loopy.el:608:1:Warning: the function ‘if-let’ is not known to be defined.
```