### PR TITLE
add-accumulation-command macro

### DIFF
--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -868,7 +868,7 @@ command names or a single command name."
     (loopy--main-body . (cl-callf2 funcall ,fn ,var ,val))))
 
 (loopy--defaccumulation-command (union unioning) (var val &key test)
-  `((main-body . (cl-callf2 cl-union ,value ,var :test ,test))))
+  `((loopy--main-body . (cl-callf2 cl-union ,value ,var :test ,test))))
 
 (loopy--defaccumulation-command (vconcat vconcating) (var val)
   `((split:implicit-return . (apply #'vconcat (nreverse ,var)))

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -849,11 +849,11 @@ command names or a single command name."
 
 (loopy--defaccumulation-command (concat concating) (var val)
   `((split:implicit-return . (apply #'concat (nreverse ,val)))
-    (main-body . (cl-callf2 cons ,val ,var))))
+    (loopy--main-body . (cl-callf2 cons ,val ,var))))
 
 (loopy--defaccumulation-command (nconc nconcing) (var val)
   `((split:implicit-return . (nreverse ,var))
-    (main-body . (cl-callf2 nconc (nreverse ,val) ,var))))
+    (loopy--main-body . (cl-callf2 nconc (nreverse ,val) ,var))))
 
 (loopy--defaccumulation-command (nunion nunioning) (var val &key test)
   `((main-body . (cl-callf2 cl-nunion ,value ,var :test ,test))))

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -856,11 +856,11 @@ command names or a single command name."
     (loopy--main-body . (cl-callf2 nconc (nreverse ,val) ,var))))
 
 (loopy--defaccumulation-command (nunion nunioning) (var val &key test)
-  `((main-body . (cl-callf2 cl-nunion ,value ,var :test ,test))))
+  `((loopy--main-body . (cl-callf2 cl-nunion ,value ,var :test ,test))))
 
 (loopy--defaccumulation-command (prepend prepending) (var val)
   `((implicit-return . ,var)
-    (main-body . (cl-callf2 nconc ,val ,var))))
+    (loopy--main-body . (cl-callf2 nconc ,val ,var))))
 
 (loopy--defaccumulation-command reducing (var val fn &key init)
   `((accumulation-vars . ,(or init (loopy--accumulation-starting-value name)))

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -865,7 +865,7 @@ command names or a single command name."
 (loopy--defaccumulation-command reducing (var val fn &key init)
   `((accumulation-vars . ,(or init (loopy--accumulation-starting-value name)))
     (implicit-return . ,var)
-    (main-body . (cl-callf2 funcall ,fn ,var ,val))))
+    (loopy--main-body . (cl-callf2 funcall ,fn ,var ,val))))
 
 (loopy--defaccumulation-command (union unioning) (var val &key test)
   `((main-body . (cl-callf2 cl-union ,value ,var :test ,test))))


### PR DESCRIPTION
This is a draft. It's not yet ready I'm still writing it. I was hoping to get some feedback so I could know if this idea is welcome.

The purpose of this PR is to facilitate creating accumulation commands by using a macro. The goal is for defining an accumulation command to be as simple as the below.

```elisp
(loopy--defaccumulation-command adjoining (test)
  "A docstring"
  `(setq ,var (cl-adjoin ,value ,var :test ,test)))
```
Additionally I think such a macro will make accumulation more modular in that each accumulation clause will have its own function.