### PR TITLE
Add optional argument `:init` for command `expr`.

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -510,9 +510,14 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
 
    #+findex: expr, exprs, set
-   - =(expr|exprs|set VAR [EXPRS])= :: Bind =VAR= to each =EXPR= in order.
-     Once the last =EXPR= is reached, it is used repeatedly for the rest of the
-     loop.  With no =EXPR=, =VAR= is repeatedly bound to =nil=.
+   - =(expr|exprs|set VAR [EXPRS] [:init INIT])= :: Bind =VAR= to each =EXPR= in
+     order.  Once the last =EXPR= is reached, it is used repeatedly for the rest
+     of the loop.  With no =EXPR=, =VAR= is repeatedly bound to =nil=.
+
+     If =INIT= is provided, use that as the initial value of =VAR=.  This could
+     also be achieved by specifying a value using the =with= special macro
+     argument.  When destructuring, each variable is initialized to =INIT=, not
+     a destructured part of =INIT=.
 
      #+ATTR_TEXINFO: :tag Note
      #+begin_quote
@@ -531,15 +536,34 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+end_quote
 
      #+BEGIN_SRC emacs-lisp
+       ;; => '(1 2 3 3 3)
        (loopy (repeat 5)
               (expr i 1 2 3)
               (collect coll i)
-              (finally-return coll)) ; => '(1 2 3 3 3)
+              (finally-return coll))
 
+       ;; => '(0 1 2 3 4)
        (loopy (repeat 5)
               (expr i 0 (1+ i))
               (collect coll i)
-              (finally-return coll)) ; => '(0 1 2 3 4)
+              (finally-return coll))
+
+       ;; Note that `i' is initialized to 0, and set to 1 in
+       ;; the middle of the first cycle of the loop.
+       ;;
+       ;; => ((0 1 2) (1 2 3))
+       (loopy (repeat 3)
+              (collect befores i)
+              (expr i 1 (1+ i) :init 0)
+              (collect afters i)
+              (finally-return befores afters))
+
+       ;; Note that using `with' has a similar effect.
+       ;; => (0 1 2)
+       (loopy (with (i 0))
+              (repeat 3)
+              (collect i)
+              (expr i 1 (1+ i)))
      #+END_SRC
 
    #+findex: group

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -183,6 +183,31 @@ The lists will be in the order parsed (correct for insertion)."
     ;; Return the sub-lists.
     (list (nreverse wrapped-main-body) (nreverse other-instructions))))
 
+;; Wrapper to make sure that the output sequence is of the same type.
+(cl-defun loopy--substitute-using (new seq &key test)
+  "Copy SEQ, substituting elements using output of NEW.
+
+NEW receives the element as its only argument.
+
+If given predicate TEST, replace only elements satisfying TEST.
+This testing could also be done in NEW."
+  (cl-map (if (cl-typep seq 'list) 'list 'array)
+          (if test
+              (lambda (x)
+                (if (funcall test x)
+                    (funcall new x)
+                  x))
+            (lambda (x) (funcall new x)))
+          seq))
+
+(cl-defun loopy--substitute-using-if (new test seq)
+  "Copy SEQ, substituting elements satisfying TEST using output of NEW.
+
+NEW receives the element as its only argument.
+
+Unlike `loopy--substitute-using', the test is required."
+  (loopy--substitute-using new seq :test test))
+
 
 ;;;; Included parsing functions.
 ;;;;; Misc.

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -242,7 +242,12 @@ implicit variable without knowing it's name, even for named loops."
                             (finally-return my-val))))
         (equal '(t t) (eval (quote (loopy (expr (i j) '(t t))
                                           (return nil) ; TODO: Change to leave.
-                                          (finally-return i j))))))))
+                                          (finally-return i j)))))
+
+        (equal '(0 1 1 1)
+               (eval (quote (loopy (repeat 4)
+                                   (collect i)
+                                   (expr i 1 :init 0))))))))
 
 (ert-deftest expr-two-values ()
   (should
@@ -256,7 +261,12 @@ implicit variable without knowing it's name, even for named loops."
            (eval (quote (loopy  (repeat 3)
                                 (expr (i j) '(1 1) '(2 2))
                                 (collect my-coll (list i j))
-                                (finally-return my-coll))))))))
+                                (finally-return my-coll)))))
+
+    (equal '(0 1 2 2)
+           (eval (quote (loopy (repeat 4)
+                               (collect i)
+                               (expr i 1 2 :init 0))))))))
 
 (ert-deftest expr-two-values-when ()
   (should (equal '(nil 0 0 1 1 2 2 3)
@@ -285,7 +295,12 @@ implicit variable without knowing it's name, even for named loops."
                                     (expr (i j) '(1 1) '(2 2)
                                           '(3 3) '(4 4) '(5 5))
                                     (collect my-coll (list i j))
-                                    (finally-return my-coll))))))))
+                                    (finally-return my-coll)))))
+
+        (equal '(0 1 2 3 4 5 5 5 5 5)
+               (eval (quote (loopy (repeat 10)
+                                   (collect i)
+                                   (expr i 1 2 3 4 5 :init 0))))))))
 
 (ert-deftest expr-dont-repeat ()
   "Make sure commands don't repeatedly create/declare the same variable."


### PR DESCRIPTION
This is a convenience argument, and works similarly to `with`.  It cannot be
destructured.

``` emacs-lisp
;; Note that `i' is initialized to 0, and set to 1 in
;; the middle of the first cycle of the loop.
;;
;; => ((0 1 2) (1 2 3))
(loopy (repeat 3)
       (collect befores i)
       (expr i 1 (1+ i) :init 0)
       (collect afters i)
       (finally-return befores afters))

;; Note that using `with' has a similar effect.
;; => (0 1 2)
(loopy (with (i 0))
       (repeat 3)
       (collect i)
       (expr i 1 (1+ i)))
```