### PR TITLE
Add `init` as alias to `with` and `no-with` as an alias to `without` 

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -202,7 +202,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   loop commands, they cannot occur in sub-loops ([[*Sub-loops][Sub-loops]]).
 
   #+findex: with, let*
-  - =with=, =let*= :: Declare variables before the loop.
+  - =with=, =let*=, =init= :: Declare variables before the loop.
 
     #+begin_src emacs-lisp
       (loopy (with (a 1) (b 2)) ...)
@@ -210,7 +210,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     #+end_src
 
   #+findex: without, no-init
-  - =without=, =no-init= :: Variables that ~loopy~ should not try to
+  - =without=, =no-with=, =no-init= :: Variables that ~loopy~ should not try to
     initialize.  ~loopy~ tries to initialize all the variables it uses in a
     ~let~-like form, but that isn’t always desired.
 

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -202,11 +202,18 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   loop commands, they cannot occur in sub-loops ([[*Sub-loops][Sub-loops]]).
 
   #+findex: with, let*
-  - =with=, =let*=, =init= :: Declare variables before the loop.
+  - =with=, =let*=, =init= :: Declare variables before the loop.  This can also
+    be used to initialize variables referenced by loop commands.
 
     #+begin_src emacs-lisp
       (loopy (with (a 1) (b 2)) ...)
       (loopy (let* (a 1) (b 2)) ...)
+
+      ;; => 16
+      (loopy (with (my-sum 10))
+             (list i '(1 2 3))
+             (sum my-sum i)
+             (finally-return my-sum))
     #+end_src
 
   #+findex: without, no-init

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -113,7 +113,7 @@ list.  For example, by default, \"(for collect i)\" and
 
 ;;;;
 (defvar loopy-iter--valid-macro-arguments
-  '( flag flags with without no-init before-do before initially-do
+  '( flag flags with init without no-init no-with before-do before initially-do
      initially after-do after else-do else finally-do finally finally-return)
   "List of valid keywords for `loopy-iter' macro arguments.
 

--- a/loopy.el
+++ b/loopy.el
@@ -192,7 +192,7 @@ Each item is of the form (FLAG . FLAG-ENABLING-FUNCTION).")
 NOTE: This functionality might change in the future.")
 
 (defvar loopy--valid-macro-arguments
-  '( flag flags with let* without no-init before-do before initially-do
+  '( flag flags with let* init without no-with no-init before-do before initially-do
      initially after-do after else-do else finally-do finally finally-return)
   "List of valid keywords for `loopy' macro arguments.
 
@@ -792,9 +792,9 @@ The macro takes several top-level arguments, all, except a loop
 name, being a list beginning with one of the keywords below.  To
 name a loop, pass in an unquoted symbol as an argument.
 
-- `with', `let*': Declare variables before the loop.
+- `with', `init', `let*': Declare variables before the loop.
 
-- `without', `no-init': Variables that `loopy' should not try to
+- `without', `no-with', `no-init': Variables that `loopy' should not try to
   initialize.  `loopy' tries to initialize all the variables it
   uses in a `let'-like form, but that isn’t always desired.
 
@@ -830,8 +830,8 @@ Info node `(loopy)' distributed with this package."
 
   (declare (debug (&rest ;; TODO: Is this correct?
                    [&or
-                    ([&or "with" "let*"] &rest (symbolp &optional form))
-                    ([&or "without" "no-init"] &rest symbolp)
+                    ([&or "with" "let*" "init"] &rest (symbolp &optional form))
+                    ([&or "without" "no-with" "no-init"] &rest symbolp)
                     ([&or "flag" "flags"] &rest symbolp)
                     ([&or "before-do" "before" "initially-do" "initially"] body)
                     [&or (symbolp ;; This one covers most commands.
@@ -880,7 +880,7 @@ Info node `(loopy)' distributed with this package."
    (setq loopy--with-vars
          (let ((result))
            (dolist (binding (loopy--find-special-macro-arguments
-                             '(with let*) body))
+                             '(with let* init) body))
              (push (cond
                     ((symbolp binding)
                      (list binding nil))
@@ -893,7 +893,7 @@ Info node `(loopy)' distributed with this package."
 
    ;; Without
    (setq loopy--without-vars
-         (loopy--find-special-macro-arguments '(without no-init) body))
+         (loopy--find-special-macro-arguments '(without no-with no-init) body))
 
    ;; Before do
    (setq loopy--before-do

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -11,14 +11,20 @@
 ;;; Macro arguments
 ;;;; With
 (ert-deftest with-arg-order ()
-  (should (and (= 4
-                  (eval (quote (loopy (with (a 2)
-                                            (b (+ a 2)))
-                                      (return b)))))
-               (= 4
-                  (eval (quote (loopy (let* (a 2)
-                                        (b (+ a 2)))
-                                      (return b))))))))
+  (should (= 4
+             (eval (quote (loopy (with (a 2)
+                                       (b (+ a 2)))
+                                 (return b))))))
+
+  (should (= 4
+             (eval (quote (loopy (let* (a 2)
+                                   (b (+ a 2)))
+                                 (return b))))))
+
+  (should (= 4
+             (eval (quote (loopy (init (a 2)
+                                       (b (+ a 2)))
+                                 (return b)))))))
 
 (ert-deftest with-destructuring ()
   (should (= -2
@@ -29,20 +35,29 @@
 
 ;;;; Without
 (ert-deftest without ()
-  (should (and (equal '(4 5)
-                      (let ((a 1) (b 2))
-                        (eval (quote (loopy (with (c 3))
-                                            (without a b)
-                                            (expr a (+ a c))
-                                            (expr b (+ b c))
-                                            (return a b))))))
-               (equal '(4 5)
-                      (let ((a 1) (b 2))
-                        (eval (quote (loopy (with (c 3))
-                                            (no-init a b)
-                                            (expr a (+ a c))
-                                            (expr b (+ b c))
-                                            (return a b)))))))))
+  (should (equal '(4 5)
+                 (let ((a 1) (b 2))
+                   (eval (quote (loopy (with (c 3))
+                                       (without a b)
+                                       (expr a (+ a c))
+                                       (expr b (+ b c))
+                                       (return a b)))))))
+
+  (should (equal '(4 5)
+                 (let ((a 1) (b 2))
+                   (eval (quote (loopy (with (c 3))
+                                       (no-init a b)
+                                       (expr a (+ a c))
+                                       (expr b (+ b c))
+                                       (return a b)))))))
+
+  (should (equal '(4 5)
+                 (let ((a 1) (b 2))
+                   (eval (quote (loopy (with (c 3))
+                                       (no-with a b)
+                                       (expr a (+ a c))
+                                       (expr b (+ b c))
+                                       (return a b))))))))
 
 ;;;; Before Do
 ;; `before-do' always runs, and occurs before the loop.


### PR DESCRIPTION
I think that `init` would be a good addition considering we're adding an `:init` keyword which will be similar to `with`. `with`->`no-with` is consistent with the pattern `init`->`no-init`.