### PR TITLE
Make never consistent with always

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1153,6 +1153,11 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        (loopy (list i '(1 0 1 0 1))
               (thereis (and (> i 2) i)))
 
+       ;; => nil
+       (loopy (list i '(1 0 1 0 1))
+	      ;; Same as above. Like `always' uses an explicit `and'.
+              (thereis (> i 2) i))
+
        ;; => 3
        (loopy (list i '(nil nil 3 nil))
               (thereis i))

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1178,6 +1178,13 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        ;; => 3
        (loopy (list i '(nil nil 3 nil))
               (thereis i))
+
+       ;; Having no conditions in `thereis' makes loopy always return true. It
+       ;; is equivalent to `(thereis t)'.
+
+       ;; => t
+       (loopy (list i '(nil nil 3 nil))
+              (thereis))
      #+END_SRC
      
 ** Control Flow

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1117,8 +1117,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 	      ;; This is equivalent to `(always (and (< i 2) (>= i 0)))'.
               (always (< i 2) (>= i 0)))
 
-       ;; Having no conditions makes the return value of `always' expand to
-       ;; `(and)' which evaluates to t.
+       ;; Having no conditions is equivalent to `(always t)'.
 
        ;; => t
        (loopy (list i '(1 0 1 0 1))

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1098,8 +1098,9 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    case the conditions are ~and~-ed.
 
    #+findex: always
-   - =(always COND &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
-     Otherwise, the loop returns ~t~.
+   - =(always &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
+     Otherwise, the loop returns ~t~. If more than one condition is specified
+     treat them as one condition joined by =and=.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t
@@ -1118,8 +1119,9 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
    
    #+findex: never
-   - =(never COND &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever non-nil.
-     Otherwise, the loop returns ~t~.
+   - =(never &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever non-nil.
+     Otherwise, the loop returns ~t~. If more than one condition is specified
+     treat them as one condition joined by =or=.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1094,11 +1094,10 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    It is incorrect to use both =thereis= and one of =always= or =never= in the
    same loop, as this leads to conflicting implicit return values.
 
-   For convenience, these commands can be passed multiple conditions, in which
-   case the conditions are ~and~-ed.
+   For convenience, these commands can be passed multiple conditions.
 
    #+findex: always
-   - =(always COND)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
+   - =(always COND [CONDS])= :: Immediately return ~nil~ if =COND= is ever ~nil~.
      Otherwise, the loop returns the final value of =COND= or ~t~ if =COND= is
      never evaluated.  If more than one condition is specified treat them as one
      condition joined by =and=.
@@ -1118,13 +1117,6 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
               ;; This is equivalent to `(always (and (< i 2) (>= i 0)))'.
               (always (< i 2) (>= i 0)))
 
-       ;; Having no conditions is equivalent to `(always t)', which always
-       ;; evaluates to t.
-       ;;
-       ;; => t
-       (loopy (list i '(1 0 1 0 1))
-              (always))
-
        ;; => "hello"
        (loopy (list i '(1 1 1 1))
               ;; The return value of `(and (< i 2) "hello")' is "hello".
@@ -1142,7 +1134,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
    
    #+findex: never
-   - =(never &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever non-nil.
+   - =(never COND [CONDS])= :: Immediately return ~nil~ if =COND= is ever non-nil.
      Otherwise, the loop returns ~t~. If more than one condition is specified
      treat them as one condition joined by =or=.
 
@@ -1162,13 +1154,6 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        (loopy (list i '(1 0 1 0 1))
 	      ;; equivalent to `(never (or (= i 3) (= i 4)))'.
               (never (= i 3) (= i 4)))
-
-       ;; Having no conditions for never is the same as `(never nil)', which
-       ;; would always evaluate to t.
-
-       ;; => t
-       (loopy (list i '(1 0 1 0 1))
-              (never))
      #+END_SRC
 
      =never= does not affect the loop's implicit return value when using the
@@ -1184,9 +1169,9 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+end_src
      
    #+findex: thereis
-   - =(thereis &rest CONDS)= :: Immediately return the value of =COND= if said value is
-     ever non-nil.  Otherwise, the loop returns ~nil~. If more than one
-     condition is specified treat them as one condition joined by =and=.
+   - =(thereis COND [CONDS])= :: Immediately return the value of =COND= if said
+     value is ever non-nil.  Otherwise, the loop returns ~nil~.  If more than
+     one condition is specified treat them as one condition joined by =and=.
 
      #+BEGIN_SRC emacs-lisp
        ;; => 3
@@ -1206,13 +1191,6 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        ;; => 3
        (loopy (list i '(nil nil 3 nil))
               (thereis i))
-
-       ;; Having no conditions in `thereis' makes loopy always return true. It
-       ;; is equivalent to `(thereis t)'.
-
-       ;; => t
-       (loopy (list i '(nil nil 3 nil))
-              (thereis))
      #+END_SRC
      
 ** Control Flow

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1129,6 +1129,14 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        ;; => nil
        (loopy (list i '(1 0 1 0 1))
               (never (= i 0)))
+
+       ;; Like `always', `never' can also accept multiple arguments. They are
+       ;; treated as `(never (or COND1 COND2 ... CONDN))'.
+
+       ;; => t
+       (loopy (list i '(1 0 1 0 1))
+	      ;; equivalent to `(never (or (= i 3) (= i 4)))'.
+              (never (= i 3) (= i 4)))
      #+END_SRC
      
    #+findex: thereis

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1109,6 +1109,12 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        ;; => nil
        (loopy (list i '(1 0 1 0 1))
               (always (< i 1)))
+
+       ;; => t
+       (loopy (list i '(1 0 1 0 1))
+	      ;; Note: can accept multiple conditions.
+	      ;; This is equivalent to `(always (and (< i 2) (>= i 0)))'.
+              (always (< i 2) (>= i 0)))
      #+END_SRC
    
    #+findex: never

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1142,8 +1142,9 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
      
    #+findex: thereis
-   - =(thereis COND &rest CONDS)= :: Immediately return the value of =COND= if said value is
-     ever non-nil.  Otherwise, the loop returns ~nil~.
+   - =(thereis &rest CONDS)= :: Immediately return the value of =COND= if said value is
+     ever non-nil.  Otherwise, the loop returns ~nil~. If more than one
+     condition is specified treat them as one condition joined by =and=.
 
      #+BEGIN_SRC emacs-lisp
        ;; => 3

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1116,6 +1116,13 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 	      ;; Note: can accept multiple conditions.
 	      ;; This is equivalent to `(always (and (< i 2) (>= i 0)))'.
               (always (< i 2) (>= i 0)))
+
+       ;; Having no conditions makes the return value of `always' expand to
+       ;; `(and)' which evaluates to t.
+
+       ;; => t
+       (loopy (list i '(1 0 1 0 1))
+              (always))
      #+END_SRC
    
    #+findex: never

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1097,10 +1097,9 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    For convenience, these commands can be passed multiple conditions.
 
    #+findex: always
-   - =(always COND [CONDS])= :: Immediately return ~nil~ if =COND= is ever ~nil~.
-     Otherwise, the loop returns the final value of =COND= or ~t~ if =COND= is
-     never evaluated.  If more than one condition is specified treat them as one
-     condition joined by =and=.
+   - =(always COND [CONDS])= :: Immediately return ~nil~ if any =COND= is ever
+     ~nil~.  Otherwise, the loop returns the final value of the last =COND= or
+     ~t~ if no =COND= is ever evaluated.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t
@@ -1134,9 +1133,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
    
    #+findex: never
-   - =(never COND [CONDS])= :: Immediately return ~nil~ if =COND= is ever non-nil.
-     Otherwise, the loop returns ~t~. If more than one condition is specified
-     treat them as one condition joined by =or=.
+   - =(never COND [CONDS])= :: Immediately return ~nil~ if any =COND= is ever
+     non-nil.  Otherwise, the loop returns ~t~.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t
@@ -1171,7 +1169,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    #+findex: thereis
    - =(thereis COND [CONDS])= :: Immediately return the value of =COND= if said
      value is ever non-nil.  Otherwise, the loop returns ~nil~.  If more than
-     one condition is specified treat them as one condition joined by =and=.
+     one condition is specified, then they are treated as one condition joined
+     by ~and~.
 
      #+BEGIN_SRC emacs-lisp
        ;; => 3

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1098,7 +1098,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    case the conditions are ~and~-ed.
 
    #+findex: always
-   - =(always COND)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
+   - =(always COND &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
      Otherwise, the loop returns ~t~.
 
      #+BEGIN_SRC emacs-lisp
@@ -1118,7 +1118,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
    
    #+findex: never
-   - =(never COND)= :: Immediately return ~nil~ if =COND= is ever non-nil.
+   - =(never COND &rest CONDS)= :: Immediately return ~nil~ if =COND= is ever non-nil.
      Otherwise, the loop returns ~t~.
 
      #+BEGIN_SRC emacs-lisp
@@ -1140,7 +1140,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
      #+END_SRC
      
    #+findex: thereis
-   - =(thereis COND)= :: Immediately return the value of =COND= if said value is
+   - =(thereis COND &rest CONDS)= :: Immediately return the value of =COND= if said value is
      ever non-nil.  Otherwise, the loop returns ~nil~.
 
      #+BEGIN_SRC emacs-lisp

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1117,7 +1117,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 	      ;; This is equivalent to `(always (and (< i 2) (>= i 0)))'.
               (always (< i 2) (>= i 0)))
 
-       ;; Having no conditions is equivalent to `(always t)'.
+       ;; Having no conditions is equivalent to `(always t)', which always
+       ;; evaluates to t.
 
        ;; => t
        (loopy (list i '(1 0 1 0 1))
@@ -1145,6 +1146,13 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        (loopy (list i '(1 0 1 0 1))
 	      ;; equivalent to `(never (or (= i 3) (= i 4)))'.
               (never (= i 3) (= i 4)))
+
+       ;; Having no conditions for never is the same as `(never nil)', which
+       ;; would always evaluate to t.
+
+       ;; => t
+       (loopy (list i '(1 0 1 0 1))
+              (never))
      #+END_SRC
      
    #+findex: thereis

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -794,8 +794,8 @@ whose value is to be accumulated."
                           (list name value-holder value-expression))))))))
 
 ;;;; Boolean Commands
-(cl-defun loopy--parse-always-command ((_ &rest conditions))
-  "Parse a command of the form `(always [CONDITIONS])'.
+(cl-defun loopy--parse-always-command ((_ condition &rest other-conditions))
+  "Parse a command of the form `(always CONDITION [CONDITIONS])'.
 
 If any condition is nil, `loopy' should immediately return nil.
 Otherwise, `loopy' should return the final value of CONDITIONS,
@@ -810,14 +810,14 @@ or t if the command is never evaluated."
       (loopy--implicit-return . ,return-val)
       (loopy--main-body . (progn
 			    (setq ,return-val
-				  ,(if (= 1 (length conditions))
-				       (cl-first conditions)
-				     `(and ,@conditions)))
+                                  ,(if other-conditions
+                                       `(and ,condition ,@other-conditions)
+                                     condition))
 			    (unless ,return-val
 			      (cl-return-from ,loopy--loop-name nil)))))))
 
-(cl-defun loopy--parse-never-command ((_ &rest conditions))
-  "Parse a command of the form `(never [CONDITIONS])'.
+(cl-defun loopy--parse-never-command ((_ condition &rest other-conditions))
+  "Parse a command of the form `(never CONDITION [CONDITIONS])'.
 
 If any condition is t, `loopy' should immediately return nil.
 Otherwise, `loopy' should return t."
@@ -829,20 +829,22 @@ Otherwise, `loopy' should return t."
                               "loopy-always-never-return-val"))))
     `((loopy--iteration-vars . (,return-val t))
       (loopy--implicit-return  . ,return-val)
-      (loopy--main-body . (when ,(if (= 1 (length conditions))
-                                     (cl-first conditions)
-                                   `(or ,@conditions))
+      (loopy--main-body . (when ,(if other-conditions
+                                     `(or ,condition ,@other-conditions)
+                                   condition)
                             (cl-return-from ,loopy--loop-name nil))))))
 
-(cl-defun loopy--parse-thereis-command ((_ &rest conditions))
-  "Parse a command of the form `(thereis [CONDITIONS]).'
+(cl-defun loopy--parse-thereis-command ((_ condition &rest other-conditions))
+  "Parse a command of the form `(thereis CONDITION [CONDITIONS]).'
 
 If any condition is non-nil, its value is immediately returned and the loop is exited.
 Otherwise the loop continues and nil is returned."
   (let ((value-holder (gensym "thereis-var-")))
     `((loopy--implicit-return  . nil)
       (loopy--main-body
-       . (if-let ((,value-holder (and ,@conditions)))
+       . (if-let ((,value-holder ,(if other-conditions
+                                      `(and ,condition ,@other-conditions)
+                                    condition)))
 	     (cl-return-from ,loopy--loop-name ,value-holder))))))
 
 ;;;;; Exiting and Skipping

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -813,7 +813,7 @@ Otherwise, `loopy' should return t."
   `((loopy--implicit-return  . t)
     (loopy--main-body . (when ,(if (= 1 (length conditions))
                                    (cl-first conditions)
-                                 `(and ,@conditions))
+                                 `(or ,@conditions))
                           (cl-return-from ,loopy--loop-name nil)))))
 
 (cl-defun loopy--parse-thereis-command ((_ &rest conditions))


### PR DESCRIPTION
As it stands, when you adding multiple conditions in the `always` command making the condition harder to return t (in general, that is obviously it depends on the conditions added).

```elisp
(loopy (list i '(1 0 1 0 1))
       (always (< i 2) (>= i 0)))

;; The set of numbers that meet the condition (and (< i 2) (>= i 0)) is less
;; than that of the set of numbers that meet the condition (< i 2).
```

However, for never, adding more conditions makes the set larger.

```elisp
(loopy (list i '(1 0 1 0 1))
       (never (< i 2) (>= i 0)))
;; The set of numbers that meet the condition (not (and (< i 2) (>= i 0))) is
;; greater than that of just (not (< i 2))
```

I think that that's why we should use `or` for `never` instead of the implied `and` so that it will also (in general) lessen the set of candidates. What do you thinK?

Also in this PR I elaborate on example of `always` (and I plan to also do so for `never).