### PR TITLE
Always return values like in iterate

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1089,7 +1089,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    Boolean commands are used to test whether a condition holds true for elements
    of a sequence.  Under certain conditions, they cause the loop to exit and
    return a value.  Like accumulation commands, they have an implicit return
-   value (~t~ for =always= and =never=, ~nil~ for =thereis=).
+   value which is used if these commands do not cause the loop to exit.
 
    It is incorrect to use both =thereis= and one of =always= or =never= in the
    same loop, as this leads to conflicting implicit return values.
@@ -1099,7 +1099,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 
    #+findex: always
    - =(always COND)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
-     Otherwise, the loop returns the return value of =COND=.
+     Otherwise, the loop returns the final value of =COND= or ~t~ if =COND= is
+     never evaluated.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t
@@ -1108,12 +1109,18 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 
        ;; => "hello"
        (loopy (list i '(1 1 1 1))
-	      ;; The return value of `(and (< i 2) "hello")' is "hello".
+              ;; The return value of `(and (< i 2) "hello")' is "hello".
               (always (< i 2) "hello"))
 
-       ;; => nil
-       (loopy (list i '(1 0 1 0 1))
-              (always (< i 1)))
+       ;; NOTE: Here, the implicit return value is `t' because an
+       ;;       `always' command was used, and that return value
+       ;;       is never updated to "hello" because the `always'
+       ;;       command is never actually used.
+       ;;
+       ;; => t
+       (loopy (list i '(1 1 1 1))
+              (when nil
+                (always (> i 5) "hello")))
      #+END_SRC
    
    #+findex: never
@@ -1129,6 +1136,18 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        (loopy (list i '(1 0 1 0 1))
               (never (= i 0)))
      #+END_SRC
+
+     =never= does not affect the loop's implicit return value when using the
+     =always= command.
+
+     #+begin_src emacs-lisp
+       ;; This example taken from the documentation of CL's Iterate package.
+       ;;
+       ;; => 2, not t
+       (loopy (repeat 2)
+              (always 2)
+              (never nil))
+     #+end_src
      
    #+findex: thereis
    - =(thereis COND)= :: Immediately return the value of =COND= if said value is

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1099,12 +1099,17 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 
    #+findex: always
    - =(always COND)= :: Immediately return ~nil~ if =COND= is ever ~nil~.
-     Otherwise, the loop returns ~t~.
+     Otherwise, the loop returns the return value of =COND=.
 
      #+BEGIN_SRC emacs-lisp
        ;; => t
        (loopy (list i '(1 0 1 0 1))
               (always (< i 2)))
+
+       ;; => "hello"
+       (loopy (list i '(1 1 1 1))
+	      ;; The return value of `(and (< i 2) "hello")' is "hello".
+              (always (< i 2) "hello"))
 
        ;; => nil
        (loopy (list i '(1 0 1 0 1))

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -799,11 +799,16 @@ whose value is to be accumulated."
 
 If any condition is nil, `loopy' should immediately return nil.
 Otherwise, `loopy' should return t."
-  `((loopy--implicit-return . t)
-    (loopy--main-body . (unless ,(if (= 1 (length conditions))
-                                     (cl-first conditions)
-                                   `(and ,@conditions))
-                          (cl-return-from ,loopy--loop-name nil)))))
+  (let ((return-val (gensym "always-return-val-")))
+    `((loopy--iteration-vars . (,return-val t))
+      (loopy--implicit-return . ,return-val)
+      (loopy--main-body . (progn
+			    (setq ,return-val
+				  ,(if (= 1 (length conditions))
+				       (cl-first conditions)
+				     `(and ,@conditions)))
+			    (unless ,return-val
+			      (cl-return-from ,loopy--loop-name nil)))))))
 
 (cl-defun loopy--parse-never-command ((_ &rest conditions))
   "Parse a command of the form `(never [CONDITIONS])'.

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -798,7 +798,8 @@ whose value is to be accumulated."
   "Parse a command of the form `(always [CONDITIONS])'.
 
 If any condition is nil, `loopy' should immediately return nil.
-Otherwise, `loopy' should return t."
+Otherwise, `loopy' should return the final value of CONDITIONS,
+or t if the command is never evaluated."
   ;; NOTE: This cannot be `gensym', as it needs to be the same for all `always'
   ;;       and `never' commands operating in the same loop.
   (let ((return-val (intern (if loopy--loop-name

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -1491,6 +1491,11 @@ Not multiple of 3: 7")))
 	   (eval (quote (loopy (list i '(1 2 3 4 5 6))
 			       (always (> i 7))))))))
 
+(ert-deftest multiple-always ()
+  (should (equal t (eval (quote (loopy (list i '(1 3 5 7))
+                                       (always (cl-oddp i))
+                                       (always (< i 10))))))))
+
 ;;;;; Never
 (ert-deftest never ()
   (should (equal nil
@@ -1500,6 +1505,21 @@ Not multiple of 3: 7")))
   (should (equal t
 		 (eval (quote (loopy (list i '(1 2 3 4 5 6))
 			             (never (< i 0))))))))
+
+(ert-deftest multiple-never ()
+  (should (equal t (eval (quote (loopy (list i '(1 3 5 7))
+                                       (never (cl-evenp i))
+                                       (never (> i 10))))))))
+
+(ert-deftest always-and-never ()
+  ;; A `never' command should not stop `always' from ultimately setting the
+  ;; return value to 2.
+  (should (= 2
+             (eval (quote (loopy (repeat 2)
+                                 (always 2)
+                                 (never nil)))))))
+
+
 
 ;;;;; Thereis
 (ert-deftest thereis ()


### PR DESCRIPTION
I realized that the never clause stays the same. But I added the ability to return a value with `always`.