### PR TITLE
Add finding command

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1094,6 +1094,41 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
               (finally-return non-nil-count))
      #+END_SRC
 
+   #+findex: find, finding
+   - =(find|finding VAR EXPR TEST &key ON-FAILURE)= :: If =TEST= is
+     non-nil, the loop stops and =EXPR= is used as a returned value.  If =TEST=
+     is never non-nil, then =ON-FAILURE= is used as a returned value, if
+     provided.
+
+     =VAR= takes the value of =EXPR= if =TEST= is non-nil or =ON-FAILURE= if the
+     loop completes successfully.  It is bound to ~nil~ during  the loop.
+
+     #+BEGIN_SRC emacs-lisp
+       ;; => 3
+       (loopy (list i '(1 2 3))
+              (finding i (> i 2)))
+
+       ;; => nil
+       (loopy (list i '(1 2 3))
+              (finding i (> i 4)))
+
+       ;; => "not found"
+       (loopy (list i '(1 2 3))
+              (finding i (> i 4) :on-failure "not found"))
+
+       ;; => 2
+       ;; Does not display message.
+       (loopy (list i '(1 2 3))
+	      (finding i (= i 2) :into found)
+	      (after-do (message "found: %s" found)))
+
+       ;; => 2
+       ;; Messages "found: 2" in echo area.
+       (loopy (list i '(1 2 3))
+	      (finding found i (= i 2))
+	      (finally-do (message "found: %s" found)))
+     #+END_SRC
+
    #+findex: max, maximize
    - =(max|maxing|maximize|maximizing VAR EXPR)= :: Repeatedly set =VAR= to the
      greater of =VAR= and the value of =EXPR=.  =VAR= starts at =-1.0e+INF=, so
@@ -1410,7 +1445,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
        (loopy (list i '(nil nil 3 nil))
               (thereis i))
      #+END_SRC
-     
+
+
 ** Control Flow
    :PROPERTIES:
    :CUSTOM_ID: control-flow

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -2117,6 +2117,26 @@ Not multiple of 3: 7")))
   (should (null (eval (quote (loopy (list i '(1 2 3 4 5 6))
 			            (thereis (> i 7))))))))
 
+;; finding
+(ert-deftest find ()
+  (should (= 3 (eval (quote (loopy (list i '(1 2 3))
+			           (find i (> i 2)))))))
+
+  (should-not (eval (quote (loopy (list i '(1 2 3))
+			          (find i (> i 4))))))
+
+  (should (= 0 (eval (quote (loopy (list i '(1 2 3))
+			           (find i (> i 4) :on-failure 0))))))
+
+  (should (= 3 (eval (quote (loopy (list i '(1 2 3))
+			           (finding i (> i 2)))))))
+
+  (should-not (eval (quote (loopy (list i '(1 2 3))
+			          (finding i (> i 4))))))
+
+  (should (= 0 (eval (quote (loopy (list i '(1 2 3))
+			           (finding i (> i 4) :on-failure 0)))))))
+
 ;;; Custom Commands
 (ert-deftest custom-command-sum ()
   (cl-defun my-loopy-sum-command ((_ target &rest items))


### PR DESCRIPTION
The purpose of this PR is to add the `finding` command from the [iterate manual](https://common-lisp.net/~loliveira/tmp/iterate-manual/iterate.html#Aggregated-Boolean-Tests). It is still in progress.

One question I had is how do we exit the loopy body but still run the `after-do` when defining a command? The `finding` command is supposed to exit the main body, but the "epilogue" code is still supposed to be run according to the iterate manual.

edit: Never mind! Found out how by looking at `leave`.