### PR TITLE
Add wrap clause

### DIFF
--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -548,15 +548,6 @@ is a function by which to update VAR (default `cdr')."
                                 ,value-holder)))
         (loopy--pre-conditions . (consp ,value-holder))))))
 
-(cl-defun loopy--parse-nested-command ((_ var val &rest other-lists))
-  "Parse the `list' loop command."
-  (when loopy--in-sub-level (loopy--signal-bad-iter 'list))
-  `((loopy--iteration-vars . (,val-holder ,val))
-    (loopy--latter-body
-     . (setq ,val-holder (,(loopy--get-function-symbol func) ,val-holder)))
-    (loopy--pre-conditions . (consp ,val-holder))
-    ,@(loopy--destructure-for-iteration-command var `(car ,val-holder))))
-
 (cl-defun loopy--parse-list-command
     ((_ var val &optional (func #'cdr)) &optional (val-holder (gensym "list-")))
   "Parse the `list' loop command.

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -872,15 +872,15 @@ a loop name, return values, or a list of both."
                 ((= 1 arg-length)  (car args))
                 (t                 `(list ,@args)))))))
       (return-from
-	  (let ((arg-length (length args)))
-            (when (zerop arg-length) ; Need at least 1 arg.
-              (signal 'loopy-wrong-number-of-arguments command))
-            `((loopy--main-body
-               . (cl-return-from ,(cl-first args)
-                   ,(cond
-                     ((= 1 arg-length) nil)
-                     ((= 2 arg-length) (cl-second args))
-                     (t                `(list ,@(cl-rest args))))))))))))
+       (let ((arg-length (length args)))
+         (when (zerop arg-length) ; Need at least 1 arg.
+           (signal 'loopy-wrong-number-of-arguments command))
+         `((loopy--main-body
+            . (cl-return-from ,(cl-first args)
+                ,(cond
+                  ((= 1 arg-length) nil)
+                  ((= 2 arg-length) (cl-second args))
+                  (t                `(list ,@(cl-rest args))))))))))))
 
 (cl-defun loopy--parse-leave-command (_)
   "Parse the `leave' command."

--- a/loopy.el
+++ b/loopy.el
@@ -681,10 +681,6 @@ The function creates quoted code that should be used by a macro."
             ;; Will always be a single expression after wrapping with `while'.
             result-is-one-expression t)
 
-      ;; Wrap while loop in forms specified by `loopy--wrapping-forms`.
-      (when loopy--wrapping-forms
-	(setq result (loopy--wrap-form loopy--wrapping-forms result)))
-      
       ;; Make sure that the implicit accumulation variable is correctly
       ;; updated after the loop, if need be.
       (when loopy--implicit-accumulation-final-update
@@ -885,7 +881,7 @@ Info node `(loopy)' distributed with this package."
    (when-let ((loopy--all-flags
                (append loopy-default-flags
                        (loopy--find-special-macro-arguments '(flag flags)
-							    body))))
+                                                            body))))
      (dolist (flag loopy--all-flags)
        (if-let ((func (cdr (assq flag loopy--flag-settings))))
            (funcall func)
@@ -915,13 +911,13 @@ Info node `(loopy)' distributed with this package."
    ;; Before do
    (setq loopy--before-do
          (loopy--find-special-macro-arguments '( before-do before
-						 initially-do initially)
+                                                 initially-do initially)
                                               body))
 
    ;; After do
    (setq loopy--after-do
          (loopy--find-special-macro-arguments '( after-do after
-						 else-do else)
+                                                 else-do else)
                                               body))
 
    ;; Finally Do
@@ -1006,13 +1002,13 @@ Info node `(loopy)' distributed with this package."
    (setq loopy--main-body (nreverse loopy--main-body)
          loopy--iteration-vars (nreverse loopy--iteration-vars)
          loopy--implicit-return (when (consp loopy--implicit-return)
-				  (if (= 1 (length loopy--implicit-return))
+                                  (if (= 1 (length loopy--implicit-return))
                                       ;; If implicit return is just a single thing,
                                       ;; don't use a list.
                                       (car loopy--implicit-return)
-				    ;; If multiple items, be sure to use a list
-				    ;; in the correct order.
-				    `(list ,@(nreverse loopy--implicit-return)))))
+                                    ;; If multiple items, be sure to use a list
+                                    ;; in the correct order.
+                                    `(list ,@(nreverse loopy--implicit-return)))))
 
 ;;;;; Constructing/Creating the returned code.
    (loopy--expand-to-loop)))

--- a/loopy.el
+++ b/loopy.el
@@ -928,7 +928,7 @@ Info node `(loopy)' distributed with this package."
    (setq loopy--final-return
          (when-let ((return-val
                      (loopy--find-special-macro-arguments 'finally-return
-							  body)))
+                                                          body)))
            (if (= 1 (length return-val))
                (car return-val)
              (cons 'list return-val))))


### PR DESCRIPTION
This is a PR to add the wrap clause. The idea is that it would wrap the loopy body with forms that "wrap" a body. The goal would be to reduce nesting.

```elisp
(loopy (wrap (with-current-buffer "*Messages*") (save-excursion) (save-match-data))
       (while (re-search-forward "hello" nil t nil))
       (collect (match-string-no-properties 0)))

;; =>
(with-current-buffer "*Messages*"
  (save-excursion
    (save-match-data
      (loopy (while (re-search-forward "hello" nil t nil))
	     (collect (match-string-no-properties 0)))
```
I am a bit unsure as to the implementation of this. I believe this is related to the questions I had in #67. I looked at commands which wrap others such as `if` `when` `unless`. Unlike those commands the `wrap` command does not take a body. But I still need access to the body of the loop so I can wrap it. 

I'm looking towards `with` because it actually wraps the body the way I want to. However with is not implemented in `loopy-commands.el` with the other commands. Perhaps this is getting at a root question. Is it possible to implement `with` as a loopy command? I think that ideally we'd want this to be possible.