### PR TITLE
Update iteration commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# CHANGELOG
+
+This document describes the user-facing changes to Loopy.
+
+## Unreleased
+
+### Breaking Changes
+
+- Commands were updated to include keyword options more like those of `cl-loop`
+  and `iterate`, such as the keywords `from`, `upfrom`, `downfrom`, `to`,
+  `upto`, `downto`, `above`, `below`, `by`. ([#73], [#65])
+
+  - List commands like `list` and `list-ref` only received `by`, which replaces
+    the optional third argument `FUNC`.
+  - `seq` and `array` (and their variants) received the above list and the
+    keyword `index`, which names a variable to hold the index.
+
+- The commands `list`, `array`, and `seq` can now take multiple sequences before
+  keyword arguments, in which case the elements of those sequences are
+  distributed.  See the documentation for more info. ([#73], [#65])
+
+### Non-Breaking Changes
+
+- The positional arguments of the `nums` command are now optional, and can be
+  supplemented with keyword from the list above. ([#73])
+- Re-arrange documentation.
+
+[#65]: https://github.com/okamsn/loopy/issues/65
+[#73]: https://github.com/okamsn/loopy/pull/73

--- a/README.org
+++ b/README.org
@@ -1,12 +1,15 @@
 #+title: Loopy: A Looping and Iteration Macro
-#+author: Earl Hyatt
-#+export_file_name: loopy
-
 # Make sure to export all headings as such.  Otherwise, some links to
 # sub-headings won’t work.
 #+options: H:6
 # Some parsers require this option to export footnotes.
 #+options: f:t
+
+# MELPA Badges
+=loopy=: [[https://melpa.org/#/loopy][file:https://melpa.org/packages/loopy-badge.svg]] \\
+=loopy-dash=: [[https://melpa.org/#/loopy-dash][file:https://melpa.org/packages/loopy-dash-badge.svg]]
+
+-----
 
 ~loopy~ is a macro meant for iterating and looping.  It is similar in usage to
 [[https://www.gnu.org/software/emacs/manual/html_node/cl/Loop-Facility.html#Loop-Facility][~cl-loop~]] but uses symbolic expressions rather than keywords.
@@ -145,20 +148,33 @@ please let me know.
 
 * How to Install
 
-  Currently, Loopy must be installed manually.  Here is how one could use
-  ~straight.el~ with ~use-package~
+  Loopy can be installed from [[https://melpa.org/#/][MELPA]] as the package =loopy=.  The optional
+  package =loopy-dash= can be installed to enable using the Dash
+  library for destructuring (instead of other methods).
 
   #+begin_src emacs-lisp
-    (use-package loopy
-      :straight (loopy :type git :host github :repo "okamsn/loopy"
-                       :files (:defaults (:exclude "loopy-dash.el"))))
+    (use-package loopy)
 
     ;; Optional support for destructuring with Dash.
     (use-package loopy-dash
       :after (loopy)
-      :demand t
-      :straight (loopy-dash :type git :host github :repo "okamsn/loopy"
-                            :files ("loopy-dash.el")))
+      :demand t)
+  #+end_src
+
+  To load all of the alternative destructuring libraries (see section [[*Multiple Kinds of Destructuring][Multiple
+  Kinds of Destructuring]]) and the alternative macro form (see section [[*Loop Commands in Arbitrary Code][Loop
+  Commands in Arbitrary Code]]), use
+
+  #+begin_src emacs-lisp
+    (use-package loopy
+      :config
+      (require 'loopy-iter)
+      (require 'loopy-pcase)
+      (require 'loopy-seq))
+
+    (use-package loopy-dash
+      :after (loopy)
+      :demand t)
   #+end_src
 
 * Multiple Kinds of Destructuring

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -42,6 +42,11 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 - [[#loop-commands][Loop Commands]]
   - [[#generic-evaluation][Generic Evaluation]]
   - [[#iteration][Iteration]]
+    - [[#generic-iteration][Generic Iteration]]
+    - [[#numeric-iteration][Numeric Iteration]]
+    - [[#sequence-iteration][Sequence Iteration]]
+    - [[#sequence-index-iteration][Sequence Index Iteration]]
+    - [[#sequence-reference-iteration][Sequence Reference Iteration]]
   - [[#accumulation][Accumulation]]
   - [[#boolean][Boolean]]
   - [[#control-flow][Control Flow]]
@@ -628,8 +633,10 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    :DESCRIPTION: Iterating through sequences, etc.
    :END:
 
-   Iteration commands bind local variables and determine when the loop ends.
-   If no command sets that condition, then the loop runs forever.
+   Iteration commands bind local variables and determine when the loop ends.  If
+   no command sets an ending condition, then the loop runs forever.  Infinite
+   loops can be exited by using early-exit commands ([[#exiting-the-loop-early]]) or
+   boolean commands ([[#boolean-commands]]).
 
    Iteration commands must occur in the top level of the ~loopy~ form or in a
    =sub-loop= command.  Trying to do something like the below will signal an
@@ -644,254 +651,584 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
               (collect j)))
    #+end_src
 
-   The =-ref= (as in “reference”) commands create ~setf~-able places instead of
-   true variables.  Like other commands, they too can use destructuring, in
-   which case the variables in the sequence =VAR= are also ~setf~-able places
-   instead of true variables.
 
-   #+ATTR_TEXINFO: :tag Note
-   #+begin_quote
    In ~loopy~, iteration commands are named after what they iterate through.
-   For example, =array= and =list= iterate through the elements of arrays and
-   lists, respectively.  For the convenience of familiarity, these commands also
-   have aliases based on their equivalent =for=-clause from ~cl-loop~.
+   For example, the =array= and =list= commands iterate through the elements of
+   arrays and lists, respectively.  For the sake of familiarity, these commands
+   also have aliases based on their equivalent =for=-clause from ~cl-loop~.  To
+   translate =for VAR in LIST= from ~cl-loop~, one can use either
+   =(list VAR LIST)= or =(in VAR LIST)=.
 
-   To translate =for VAR in LIST= from ~cl-loop~ to ~loopy~, one can use either
-   =(list VAR LIST)= or =(in VAR LIST)=.  This can be helpful when using
-   ~loopy-iter~ ([[#loopy-iter][The ~loopy-iter~ Macro]]), in which case you could write any of
-   =(for list VAR LIST)=, =(for in VAR LIST)=, or =(in VAR LIST)=, depending on
-   whether you have enabled the =lax-naming= flag.
-   #+end_quote
 
-   The available iteration commands are:
+*** Generic Iteration
+   :PROPERTIES:
+   :CUSTOM_ID: generic-iteration
+   :DESCRIPTION: Looping a certain number of times.
+   :END:
 
-   #+findex: array, string, across
-   - =(array|string|across VAR EXPR)= :: Loop through the elements of the array
-     =EXPR=.  In Emacs Lisp, strings are arrays whose elements are characters.
+    #+findex: repeat
+    - =(repeat [VAR] EXPR)= :: Add a condition that the loop should stop after
+      =EXPR= iterations.  If specified, =VAR= starts at 0, and is incremented by
+      1 at the end of the loop.
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (array i [1 2 3])
-              (do (message "%d" i)))
+      #+BEGIN_SRC emacs-lisp
+        (loopy (repeat 3)
+               (do (message "Messaged three times.")))
 
-       ;; Collects the integer values representing each character.
-       ;; => (97 98 99)
-       (loopy (string c "abc")
-              (collect c))
-     #+END_SRC
+        (loopy (repeat i 3)
+               (do (message "%d" i)))
+      #+END_SRC
 
-   #+findex: array-ref, arrayf, string-ref, stringf, across-ref
-   - =(array-ref|arrayf|string-ref|stringf|across-ref VAR EXPR)= :: Loop through
-     the elements of the array =EXPR=, binding =VAR= as a ~setf~-able place.
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (with (my-str "cat"))
-              (array-ref i my-str)
-              (do (setf i ?a))
-              (finally-return my-str)) ; => "aaa"
-     #+END_SRC
 
-   #+findex: cons, conses, on
-   - =(cons|conses|on VAR EXPR [FUNC])= :: Loop through the cons cells of =EXPR=.
-     Optionally, find the cons cells via =FUNC= instead of =cdr=.
+*** Numeric Iteration
+    :PROPERTIES:
+    :CUSTOM_ID: numeric-iteration
+    :DESCRIPTION: Iterating through numbers.
+    :END:
 
-     To avoid unneeded variables, when not destructuring, =VAR= is initialized
-     to =EXPR= instead of ~nil~.
+    For iterating through numbers, there is the general =nums= command, and its
+    variants =nums-up= and =nums-down=.
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (cons i '(1 2 3))
-              (collect coll i)
-              (finally-return coll)) ; => ((1 2 3) (2 3) (3))
-     #+END_SRC
+    #+findex: num, nums, number, numbers
+    - =(nums|num|number|numbers VAR [START [END]] &key KEYS)= :: Iterate through
+      numbers.  =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=,
+      =upto=, =downto=, =above=, =below=, and =by=.
 
-   #+findex: list, in, each
-   - =(list|in|each VAR EXPR [FUNC])= :: Loop through each element of the list
-     =EXPR=.  Optionally, update the list by =FUNC= instead of =cdr=.
+      The command =nums= is used to iterate through numbers.  For example, =(nums
+      i 1 10)= is similar to =(list i (number-sequence 1 10))=, and =(nums i 3)=
+      is similar to =(expr i 3 (1+ i))=.
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (list i (number-sequence 1 10 3)) ; Inclusive, so '(1 4 7 10).
-              (do (message "%d" i)))
-     #+END_SRC
+      To balance convenience and similarity to other commands, =nums= has a
+      flexible argument list.  In its most basic form, it uses no keywords and
+      takes a starting value and an ending value.  The ending value is inclusive.
 
-   #+findex: list-ref, listf, in-ref
-   - =(list-ref|listf|in-ref VAR EXPR [FUNC])= :: Loop through the elements of
-     the list =EXPR=, binding =VAR= as a ~setf~-able place.  Optionally, update
-     the list by =FUNC= instead of =cdr=.
+      #+begin_src emacs-lisp
+        ;; => (1 2 3 4 5)
+        (loopy (nums i 1 5)
+               (collect i))
+      #+end_src
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (with (my-list '(1 2 3)))
-              (list-ref i my-list)
-              (do (setf i 7))
-              (finally-return my-list)) ; Returns '(7 7 7).
-     #+END_SRC
+      If the ending value is not given, then the value is incremented by 1
+      without end.
 
-   #+findex: map
-   - =(map VAR EXPR)= :: Iterate through the key-value pairs of =EXPR=, using
-     the =map.el= library.  This library generalizes working with association
-     lists ("alists"), property lists ("plists"), hash-tables, and vectors.
+      #+begin_src emacs-lisp
+        ;; => (7 8 9 10 11 12 13 14 15 16)
+        (loopy (repeat 10)
+               (nums i 7)
+               (collect i))
+      #+end_src
 
-     In each undotted pair assigned to =VAR=, the first element is the key and
-     the second element is the value.  For vectors, the key is the index.  You
-     should not rely on the order in which the key-value pairs are found.
+      To specify the step size, one can use the keyword =:by=.  The step size
+      argument should always be positive.
 
-     These pairs are created before the loop begins.  In other words, the map
-     =EXPR= is not processed progressively, but all at once.  Therefore, this
-     command can have a noticeable start-up cost when working with very large
-     maps.
+      #+begin_src emacs-lisp
+        ;; => (1 3 5)
+        (loopy (nums i 1 5 :by 2)
+               (collect i))
 
-     #+begin_src emacs-lisp
-       ;; NOTE: `pair' is not dotted.
-       ;; => ((a 1) (b 2))
-       (loopy (map pair '((a . 1) (b . 2)))
-              (collect pair))
+        ;; => (7 9 11 13 15 17 19 21 23 25)
+        (loopy (repeat 10)
+               (nums i 7 :by 2)
+               (collect i))
 
-       ;; => ((a b) (1 2))
-       (loopy (map (key value) '((a . 1) (b . 2)))
-              (collect keys key)
-              (collect values value))
+        ;; => (1 2.5 4.0)
+        (loopy (nums i 1 5 :by 1.5)
+               (collect i))
+      #+end_src
 
-       ;; => ((:a :b) (1 2))
-       (loopy (map (key value) '(:a  1 :b 2))
-              (collect keys key)
-              (collect values value))
+      By default, the variable's value starts at 0 and increases by 1.  To
+      specify that the value should be increasing or decreasing, one can use the
+      keywords =:downfrom=, =:downto=, =:upfrom=, and =:upto=.  The keywords
+      =:from= and =:to= don't by themselves specify a direction.
 
-       ;; NOTE: For vectors, the keys are indices.
-       ;; => ((0 1) (1 2))
-       (loopy (map (key value) [1 2])
-              (collect keys key)
-              (collect values value))
+      #+begin_src emacs-lisp
+        ;; => (3 2 1)
+        (loopy (repeat 3)
+               (nums i :downfrom 3)
+               (collect i))
 
-       ;; => ((a b) (1 2))
-       (let ((my-table (make-hash-table)))
-         (puthash 'a 1 my-table)
-         (puthash 'b 2 my-table)
+        ;; => (0 -1 -2 -3)
+        (loopy (nums i :downto -3)
+               (collect i))
 
-         (loopy (map (key value) my-table)
-                (collect keys key)
-                (collect values value)))
-     #+end_src
+        ;; => (10 9 8 7 6 5 4 3 2)
+        (loopy (nums i :downfrom 10 :to 2)
+               (collect i))
 
-   #+findex: num, nums, number, numbers
-   - =(nums|num|number|numbers VAR START [END] &key by down)= :: Increment =VAR=
-     from =START= through =END=.  =by= is a _positive_ value used to adjust
-     =VAR=.  =down= determines whether =VAR= is incremented or decremented.
+        ;; => (10 8 6 4 2)
+        (loopy (nums i :from 10 :downto 2 :by 2)
+               (collect i))
 
-     The values of =START=, =END=, and =by= are all computed during
-     initialization.  They do not change during the loop.
+        ;; => (1 2 3 4 5 6 7)
+        (loopy (nums i :from 1 :upto 7)
+               (collect i))
+      #+end_src
 
-     =VAR= is initialized to =START=.  The loop ends when =VAR= is either
-     greater or less than =END= (if given), depending on the value of =down=.
+      To specify an /exclusive/ ending value, use the keywords =:below= for
+      increasing values and =:above= for decreasing values.
 
-     Without =by=, the default step is 1.  Without =down=, =VAR= increases.
+      #+begin_src emacs-lisp
+        ;; => (1 2 3 4 5 6 7 8 9)
+        (loopy (nums i :from 1 :below 10)
+               (collect i))
 
-     This command does not support destructuring.
+        ;; Same as
+        (loopy (expr i 1 (1+ i))
+               (while (< i 10))
+               (collect i))
 
-     #+begin_src emacs-lisp
-       ;; => (1 2 3 4 5)
-       (loopy (nums i 1 5)
-              (collect i))
+        ;; => (10 9 8 7 6 5 4 3 2)
+        (loopy (nums i :from 10 :above 1)
+               (collect i))
 
-       ;; => (1 3 5)
-       (loopy (nums i 1 5 :by 2)
-              (collect i))
+        ;; => (0 -1 -2)
+        (loopy (nums i :above -3)
+               (collect i))
+      #+end_src
 
-       ;; => (5 3 1)
-       (loopy (nums i 5 1 :by 2 :down t)
-              (collect i))
 
-       ;; => (0 7 14)
-       (loopy (repeat 3)
-              ;; We can use `repeat' to avoid an infinite loop.
-              (nums i 0 :by 7)
-              (collect i))
+    If you prefer using positional arguments to keyword arguments, you can use
+    the commands =nums-up= and =nums-down= to specify directions.  These
+    commands are simple wrappers of the above =nums= command.
 
-       ;; => (0 -7 -14 -21 -28 -35 -42)
-       (loopy (repeat 7)
-              ;; We can use `repeat' to avoid an infinite loop.
-              (nums i 0 :by 7 :down t)
-              (collect i))
-     #+end_src
+    #+findix: nums-down, numbers-down
+    - =(nums-down|numsdown|numbers-down VAR START [END] &key by)= :: Equivalent
+      to =(nums VAR START [:downto END] &key by)=.  This command exists only for
+      convenience.
 
-   #+findix: nums-down, numbers-down
-   - =(nums-down|numsdown|numbers-down VAR START [END] &key by)= :: Equivalent
-     to =(nums VAR START [END] :down t &key by)=.  This command exists only for
-     convenience.
+      #+begin_src emacs-lisp
+        ;; => (10 8 6 4 2)
+        (loopy (nums-down i 10 1 :by 2)
+               (collect i))
+      #+end_src
 
-     #+begin_src emacs-lisp
-       ;; => (10 8 6 4 2)
-       (loopy (nums-down i 10 1 :by 2)
-              (collect i))
-     #+end_src
+    #+findix: nums-up, numbers-up
+    - =(nums-up|numsup|numbers-up VAR START [END] &key by)= :: Equivalent to
+      =(nums VAR START [END] &key by)=.  This command exists only for
+      convenience.
 
-   #+findix: nums-up, numbers-up
-   - =(nums-up|numsup|numbers-up VAR START [END] &key by)= :: Equivalent to
-     =(nums VAR START [END] &key by)=.  This command exists only for
-     convenience.
+      #+begin_src emacs-lisp
+        ;; => (1 3 5 7 9)
+        (loopy (nums-up i 1 10 :by 2)
+               (collect i))
+      #+end_src
 
-     #+begin_src emacs-lisp
-       ;; => (1 3 5 7 9)
-       (loopy (nums-up i 1 10 :by 2)
-              (collect i))
-     #+end_src
 
-   #+findex: repeat
-   - =(repeat [VAR] EXPR)= :: Add a condition that the loop should stop after
-     =EXPR= iterations.  If specified, =VAR= starts at 0, and is incremented by
-     1 at the end of the loop.
+*** Sequence Iteration
+    :PROPERTIES:
+    :CUSTOM_ID: sequence-iteration
+    :DESCRIPTION: Iterating through sequences.
+    :END:
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (repeat 3)
-              (do (message "Messaged three times.")))
+    These commands provide various ways to iterate through sequences
+    ([[info:elisp#Sequences Arrays Vectors]]).
 
-       (loopy (repeat i 3)
-              (do (message "%d" i)))
-     #+END_SRC
+    #+cindex: sequence element distribution
+    Instead of just one sequence, the =array=, =list=, and =seq= commands can be
+    given multiple sequences of various sizes.  In such cases, the elements of
+    the sequences are {{{dfn(distributed)}}}, like in the distributive property
+    from mathematics.  A new sequence of distributed elements is created before
+    the loop runs, and that sequence is used for iteration instead of the source
+    sequences.  As seen in the below example, the resulting behavior is similar
+    to that of nested loops.
 
-   #+findex: seq, sequence, elements
-   - =(seq|sequence|elements VAR EXPR)= :: Loop through the sequence =EXPR=,
-     binding =VAR= to the elements of the sequence.
+    #+begin_src emacs-lisp
+      ;; => ((1 3 6) (1 4 6) (1 5 6) (2 3 6) (2 4 6) (2 5 6))
+      (loopy (list i '(1 2) '(3 4 5) '(6))
+             (collect i))
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (seq i [1 2 3])
-              (collect coll i)
-              (finally-return coll)) ; => (1 2 3)
-     #+END_SRC
+      ;; Gives the same result as this
+      (let ((result nil))
+        (dolist (i '(1 2))
+          (dolist (j '(3 4 5))
+            (dolist (k '(6))
+              (push (list i j k) result))))
+        (nreverse result))
 
-   #+findex: seq-index, seqi, array-index, arrayi, list-index, listi, string-index, stringi
-   - =(seq-index|array-index|list-index|string-index VAR VAL)= :: Iterate
-     through the indices of =VAL=.  The loop ends when =VAR= is equal to the
-     length of =VAL=.
+      ;; and this
+      (cl-loop for i in '(1 2)
+               append (cl-loop for j in '(3 4 5)
+                               append (cl-loop for k in '(6)
+                                               collect (list i j k))))
+    #+end_src
 
-     For convenience, this command also has the aliases =seqi=, =arrayi=,
-     =listi=, and =stringi=, analogous to the command aliases =seqf=, =arrayf=,
-     =listf=, and =stringf=.
 
-     This command does not support destructuring.
+    The =array= and =sequence= commands can use the same keywords as the =nums=
+    command ([[#numeric-iteration]]) for working with the index and choosing a range
+    of the sequence elements through which to iterate.  In addition to those
+    keywords, they also have an =index= keyword, which names the variable used
+    to store the accessed index during the loop.
 
-     #+begin_src emacs-lisp
-       ;; => (0 1 2)
-       (loopy (seq-index i [1 2 3])
-              (collect i))
+    Keep in mind that if used with sequence distribution, these keywords affect
+    iterating through the sequence of distributed elements.  That is, they do
+    not affect how said sequence is produced.  In the example below, see that
+    ~cddr~ is applied to the sequence of distributed elements. It is /not/
+    applied to the source sequences.
 
-       ;; => (0 1 2)
-       (loopy (array-index i "abc")
-              (collect i))
+    #+begin_src emacs-lisp
+      ;; This code creates the sequence of distributed elements
+      ;; ((1 4) (1 5) (1 6) (2 4) (2 5) (2 6) (3 4) (3 5) (3 6))
+      ;; and then moves through this sequence using `cddr'.
+      ;;
+      ;; => ((1 4) (1 6) (2 5) (3 4) (3 6))
+      (loopy (list i '(1 2 3) '(4 5 6) :by #'cddr)
+             (collect i))
 
-       ;; => (0 1 2)
-       (loopy (list-index i '(1 2 3))
-              (collect i))
-     #+end_src
+      ;; Not the same as:
+      ;; => ((1 4) (1 6) (3 4) (3 6))
+      (loopy (list i '(1 3) '(4 6))
+             (collect i))
+    #+end_src
 
-   #+findex: seq-ref, seqf, sequence-ref, sequencef, elements-ref
-   - =(seq-ref|seqf|sequence-ref|sequencef|elements-ref VAR EXPR)= :: Loop
-     through the elements of the sequence =EXPR=, binding =VAR= as a ~setf~-able
-     place.
 
-     #+BEGIN_SRC emacs-lisp
-       (loopy (with (my-seq '(1 2 3 4)))
-              (seq-ref i my-seq)
-              (do (setf i 7))
-              (finally-return my-seq)) ; => '(7 7 7 7)
-     #+END_SRC
+    #+findex: array, string, across
+    - =(array|string|across VAR EXPR [EXPRS] &key KEYS)= :: Loop through the
+      elements of the array =EXPR=.  In Emacs Lisp, strings are arrays whose
+      elements are characters.
+
+      =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+      =downto=, =above=, =below=, =by=, and =index=.  =index= names the variable
+      used to store the index being accessed.  For others, see the =nums=
+      command.
+
+      If multiple arrays are given, then the elements of these arrays are
+      distributed into an array of lists and the above keywords apply to this
+      new resulting array.
+
+      #+BEGIN_SRC emacs-lisp
+        (loopy (array i [1 2 3])
+               (do (message "%d" i)))
+
+        ;; => (1 3)
+        (loopy (array i [1 2 3 4] :by 2)
+               (collect i))
+
+        ;; Collects the integer values representing each character.
+        ;; => (97 98 99)
+        (loopy (string c "abc")
+               (collect c))
+
+        ;; This is the same as using [(1 3) (1 4) (2 3) (2 4)].
+        ;; => ((1 3) (1 4) (2 3) (2 4))
+        (loopy (array i [1 2] [3 4])
+               (collect i))
+
+        ;; => ((1 3) (2 3))
+        (loopy (array i [1 2] [3 4] :by 2)
+               (collect i))
+      #+END_SRC
+
+    #+findex: cons, conses, on
+    - =(cons|conses|on VAR EXPR &key by)= :: Loop through the cons cells of
+      =EXPR=.  Optionally, find the cons cells via function =by= instead of
+      =cdr=.
+
+      #+BEGIN_SRC emacs-lisp
+        (loopy (cons i '(1 2 3))
+               (collect coll i)
+               (finally-return coll)) ; => ((1 2 3) (2 3) (3))
+      #+END_SRC
+
+    #+findex: list, in, each
+    - =(list|in|each VAR EXPR [EXPRS] &key by)= :: Loop through each element of
+      the list =EXPR=.  Optionally, update the list by =by= instead of =cdr=.
+
+      If multiple lists are given, distribute the elements of the lists into one
+      new list.  In such cases, =by= applies to the new list, not the arguments
+      of the command.
+
+      #+BEGIN_SRC emacs-lisp
+        (loopy (list i (number-sequence 1 10 3)) ; Inclusive, so '(1 4 7 10).
+               (do (message "%d" i)))
+
+        ;; => ((1 4) (1 5) (1 6) (2 4) (2 5) (2 6) (3 4) (3 5) (3 6))
+        (loopy (list i '(1 2 3) '(4 5 6))
+               (collect i))
+
+        ;; => ((1 4) (1 6) (2 5) (3 4) (3 6))
+        (loopy (list i '(1 2 3) '(4 5 6) :by #'cddr)
+               (collect i))
+      #+END_SRC
+
+    #+findex: map
+    - =(map VAR EXPR)= :: Iterate through the key-value pairs of =EXPR=, using
+      the =map.el= library.  This library generalizes working with association
+      lists ("alists"), property lists ("plists"), hash-tables, and vectors.
+
+      In each undotted pair assigned to =VAR=, the first element is the key and
+      the second element is the value.  For vectors, the key is the index.  You
+      should not rely on the order in which the key-value pairs are found.
+
+      These pairs are created before the loop begins.  In other words, the map
+      =EXPR= is not processed progressively, but all at once.  Therefore, this
+      command can have a noticeable start-up cost when working with very large
+      maps.
+
+      #+begin_src emacs-lisp
+        ;; NOTE: `pair' is not dotted.
+        ;; => ((a 1) (b 2))
+        (loopy (map pair '((a . 1) (b . 2)))
+               (collect pair))
+
+        ;; => ((a b) (1 2))
+        (loopy (map (key value) '((a . 1) (b . 2)))
+               (collect keys key)
+               (collect values value))
+
+        ;; => ((:a :b) (1 2))
+        (loopy (map (key value) '(:a  1 :b 2))
+               (collect keys key)
+               (collect values value))
+
+        ;; NOTE: For vectors, the keys are indices.
+        ;; => ((0 1) (1 2))
+        (loopy (map (key value) [1 2])
+               (collect keys key)
+               (collect values value))
+
+        ;; => ((a b) (1 2))
+        (let ((my-table (make-hash-table)))
+          (puthash 'a 1 my-table)
+          (puthash 'b 2 my-table)
+
+          (loopy (map (key value) my-table)
+                 (collect keys key)
+                 (collect values value)))
+      #+end_src
+
+
+    #+findex: seq, sequence, elements
+    - =(seq|sequence|elements VAR EXPR [EXPRS] &key KEYS)= :: Loop
+      through the sequence =EXPR=, binding =VAR= to the elements of the sequence.
+
+      =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+      =downto=, =above=, =below=, =by=, and =index=.  =index= names the variable
+      used to store the index being accessed.  For others, see the =nums=
+      command.
+
+      If multiple sequences are given, then these keyword arguments apply to the
+      resulting sequence of distributed elements.
+
+      #+BEGIN_SRC emacs-lisp
+        ;; => (1 2 3)
+        (loopy (seq i [1 2 3])
+               (collect coll i)
+               (finally-return coll))
+
+        ;; => (0 2 4)
+        (loopy (seq i [0 1 2 3 4 5] :by 2)
+               (collect i))
+
+        ;; => (1 3 5)
+        (loopy (seq i [0 1 2 3 4 5 6]
+                    :by 2 :from 1 :to 5)
+               (collect i))
+
+        ;; => (5 3 1)
+        (loopy (seq i '(0 1 2 3 4 5 6)
+                    :downfrom 5 :by 2 :to 1)
+               (collect i))
+
+        ;; => ((1 3) (1 4) (2 3) (2 4))
+        (loopy (seq i [1 2] '(3 4))
+               (collect i))
+
+        ;; => ((1 3) (2 3))
+        (loopy (seq i [1 2] '(3 4) :by 2)
+               (collect i))
+      #+END_SRC
+
+*** Sequence Index Iteration
+    :PROPERTIES:
+    :CUSTOM_ID: sequence-index-iteration
+    :DESCRIPTION: Iterating through indices without accessing values.
+    :END:
+
+    This command is for iterating the a sequence's indices without accessing the
+    actual values of that sequence.  This is helpful if you know ahead of time
+    that you are only interested in a small subset of the sequence's elements.
+
+    As with the =array= and =seq= commands, the =seq-index= command can use the
+    same keywords as the =nums= command ([[#numeric-iteration]]) for working with
+    the index and choosing a range of the sequence elements through which to
+    iterate.  In addition to those keywords, it also has an =index= keyword,
+    which names the variable used to store the accessed index during the loop.
+
+    #+findex: seq-index, seqi, array-index, arrayi, list-index, listi, string-index, stringi
+    - =(seq-index|array-index|list-index|string-index VAR VAL &key KEYS)= :: Iterate
+      through the indices of =VAL=.
+
+      =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+      =downto=, =above=, =below=, and =by=.  For their meaning, see the =nums=
+      command.  This command is very similar to =nums=, except that it can
+      automatically end the loop when the final element is reached.  With
+      =nums=, one would first need to explicitly calculate the length of the
+      sequence.
+
+      #+begin_src emacs-lisp
+        ;; => (97 98 99 100 101 102)
+        (loopy (with (my-string "abcdef"))
+               (string-index idx my-string)
+               (collect (aref my-string idx)))
+
+        ;; Works the same as
+        (loopy (with (my-string "abcdef"))
+               (nums idx :from 0 :below (length my-string))
+               (collect (aref my-string idx)))
+      #+end_src
+
+      For convenience, this command also has the aliases =seqi=, =arrayi=,
+      =listi=, and =stringi=, analogous to the command aliases =seqf=, =arrayf=,
+      =listf=, and =stringf=.
+
+      This command does not support destructuring.
+
+      #+begin_src emacs-lisp
+        ;; => (0 1 2)
+        (loopy (seq-index i [1 2 3])
+               (collect i))
+
+        ;; => (0 1 2)
+        (loopy (array-index i "abc")
+               (collect i))
+
+        ;; => (0 1 2)
+        (loopy (list-index i '(1 2 3))
+               (collect i))
+
+        ;; => (8 6 4 2)
+        (loopy (with (my-seq [0 1 2 3 4 5 6 7 8 9 10]))
+               (seq-index idx my-seq :from 8 :downto 1 :by 2)
+               (collect (elt my-seq idx)))
+      #+end_src
+
+*** Sequence Reference Iteration
+    :PROPERTIES:
+    :CUSTOM_ID: sequence-reference-iteration
+    :DESCRIPTION: Iterating through places/fields in sequences.
+    :END:
+
+    These commands all iterate through ~setf~-able places as generalized
+    variables ([[info:elisp#Generalized Variables]]).  These generalized variables
+    are commonly called "references", "fields", or "places".  The below example
+    demonstrates using ~(nth 1 my-list)~ and ~(aref my-array 1)~ as ~setf~-able
+    places.
+
+    #+begin_src emacs-lisp
+      ;; => (1 99 3 4 5)
+      (let ((my-list '(1 2 3 4 5)))
+        (setf (nth 1 my-list) 99)
+        my-list)
+
+      ;; => [(1 2 3) (4 . 99)]
+      (let ((my-array [(1 2 3) (4 5 6)]))
+        (setf (cdr (aref my-array 1)) 99)
+        my-array)
+    #+end_src
+
+    Like other commands, field/reference commands can also use destructuring, in
+    which case the fields/places of the sequence are destructured into
+    "sub-fields", like the ~cdr~ of the second array element in the example
+    above.
+
+    As with the =array= and =seq= commands, the =array-ref= and =seq-ref=
+    commands can use the same keywords as the =nums= command
+    ([[#numeric-iteration]]) for working with the index and choosing a range of the
+    sequence elements through which to iterate.  In addition to those keywords,
+    they also have an =index= keyword, which names the variable used to store
+    the accessed index during the loop.
+
+    #+findex: array-ref, arrayf, string-ref, stringf, across-ref
+    - =(array-ref|arrayf|string-ref|stringf|across-ref VAR EXPR &key KEYS)= :: Loop
+      through the elements of the array =EXPR=, binding =VAR= as a ~setf~-able
+      place.
+
+      =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+      =downto=, =above=, =below=, =by=, and =index=.  =index= names the variable
+      used to store the index being accessed.  For others, see the =nums=
+      command.
+
+      #+BEGIN_SRC emacs-lisp
+        ;; => "aaa"
+        (loopy (with (my-str "cat"))
+               (array-ref i my-str)
+               (do (setf i ?a))
+               (finally-return my-str))
+
+        ;; => "0a2a4a6a89"
+        (loopy (with (my-str "0123456789"))
+               (array-ref i my-str :from 1 :by 2 :to 7)
+               (do (setf i ?a))
+               (finally-return my-str))
+
+        ;; Works the same as
+        (loopy (with (my-str "0123456789"))
+               (nums idx 1 7 :by 2)
+               (do (setf (aref my-str idx) ?a))
+               (finally-return my-str))
+      #+END_SRC
+
+    #+findex: list-ref, listf, in-ref
+    - =(list-ref|listf|in-ref VAR EXPR &key by)= :: Loop through the elements of
+      the list =EXPR=, binding =VAR= as a ~setf~-able place.  Optionally, update
+      the list via function =by= instead of =cdr=.
+
+      #+BEGIN_SRC emacs-lisp
+        ;; => (7 7 7)
+        (loopy (with (my-list '(1 2 3)))
+               (list-ref i my-list)
+               (do (setf i 7))
+               (finally-return my-list))
+
+        ;; Works similar to
+        (loopy (with (my-list '(1 2 3)))
+               (nums idx :below (length my-list))
+               (do (setf (nth idx my-list) 7))
+               (finally-return my-list))
+
+        ;; => (7 2 7)
+        (loopy (with (my-list '(1 2 3)))
+               (list-ref i my-list :by #'cddr)
+               (do (setf i 7))
+               (finally-return my-list))
+
+        ;; => ([1 7] [2 7])
+        (loopy (with (my-list '([1 2] [2 3])))
+               (list-ref [_ i] my-list)
+               (do (setf i 7))
+               (finally-return my-list))
+      #+END_SRC
+
+    #+findex: seq-ref, seqf, sequence-ref, sequencef, elements-ref
+    - =(seq-ref|seqf|sequence-ref|sequencef|elements-ref VAR EXPR &key KEYS)= :: Loop
+      through the elements of the sequence =EXPR=, binding =VAR= as a
+      ~setf~-able place.
+
+      =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+      =downto=, =above=, =below=, =by=, and =index=.  =index= names the variable
+      used to store the index being accessed.  For others, see the =nums=
+      command.
+
+      #+BEGIN_SRC emacs-lisp
+        ;; => (7 7 7 7)
+        (loopy (with (my-seq '(1 2 3 4)))
+               (seq-ref i my-seq)
+               (do (setf i 7))
+               (finally-return my-seq))
+
+        ;; => (0 cat 2 cat 4 cat 6 cat 8 cat)
+        (loopy (with (my-list '(0 1 2 3 4 5 6 7 8 9)))
+               (seq-ref i my-list :from 1 :by 2 )
+               (do (setf i 'cat))
+               (finally-return my-list))
+
+        ;; => "0123456a8a"
+        (loopy (with (my-str "0123456789"))
+               (seq-ref i my-str :downto 6 :by 2 )
+               (do (setf i ?a))
+               (finally-return my-str))
+      #+END_SRC
 
 ** Accumulation
    :PROPERTIES:
@@ -1890,7 +2227,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   loop command =list= and the function ~list~), a loop command must be preceded
   by one of the keywords =for=, =accum=, or =exit=.  These keywords do not share
   a name with any built-in Emacs feature and are similar to the keywords used by
-  other packages.
+  other packages.  For example, =(list VAR LIST)= would be =(for list VAR LIST)=
+  or =(for in VAR LIST)=.
 
   Any keyword in the user option ~loopy-iter-command-keywords~ can be used to
   identify any loop command.  For example, =(accum collect a)= and
@@ -1899,8 +2237,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 
   To disable this requirement, use the flag =lax-naming= ([[#flags][Using Flags]]).  When
   using =lax-naming=, ~loopy-iter~ will always prefer built-in features to loop
-  commands.  E.g., "list" will always be understood as referring to the function
-  ~list~ and not the loop command =list=.
+  commands.  For example, "list" will always be understood as referring to the
+  function ~list~ and not the loop command =list=.
 
   #+vindex: loopy-iter-ignored-commands
   If for some reason you wish for ~loopy-iter~ to ignore a loop command while

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.4
-;; Package-Requires: ((emacs "27.1") (loopy "0.4"))
+;; Version: 0.5.2
+;; Package-Requires: ((emacs "27.1") (loopy "0.5"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs alists
 
@@ -43,6 +43,41 @@
 ;; `(loopy)'.
 
 ;;; Code:
+
+;; NOTE:
+;;
+;; For more easily finding loop commands using Imenu, you might wish to do
+;; something like the below, which should work for most definitions.
+;;
+;; (progn
+;;   (push (list "Loop Commands"
+;;               (rx (seq bol
+;;                        (zero-or-more (syntax whitespace))
+;;                        "(loopy--def"
+;;                        (or "iteration" "accumulation")
+;;                        (one-or-more (syntax whitespace))
+;;                        (group (one-or-more (or (syntax word)
+;;                                                (syntax symbol)
+;;                                                (seq "\\" nonl))))))
+;;               1)
+;;         imenu-generic-expression)
+;;   (push (list "Loop Commands"
+;;               (rx (seq bol
+;;                        (zero-or-more (syntax whitespace))
+;;                        "(defun loopy--parse-"
+;;                        (group (one-or-more (or (syntax word)
+;;                                                (syntax symbol)
+;;                                                (seq "\\" nonl))))
+;;                        "-command"))
+;;               1)
+;;         imenu-generic-expression))
+
+;; TODO:
+;; - Clean up old code to use newer features:
+;;   - Use `loopy--extract-main-body' in more places.
+;;   - Use `loopy--apply-function' in more places.
+
+
 ;; Cant require `loopy', as that would be recursive.
 (require 'cl-lib)
 (require 'seq)
@@ -157,8 +192,8 @@ as `(quote my-var)' or `(function my-func)' inside the body.  For
 expansion, we generally only want the actual symbol."
   (if (symbolp function-form)
       function-form
-    (cl-case (car function-form)
-      ((function quote) (cadr function-form))
+    (cl-case (cl-first function-form)
+      ((function quote cl-function) (cl-second function-form))
       (lambda function-form)
       (t (error "This function form is unrecognized: %s" function-form)))))
 
@@ -181,10 +216,32 @@ For functions, use `loopy--get-function-symbol'."
   "Whether FORM-OR-SYMBOL is quoted via `quote' or `function'.
 
 If not, then it is possible that FORM is a variable."
+
   (and (listp form-or-symbol)
        (= 2 (length form-or-symbol))
        (or (eq (car form-or-symbol) 'quote)
-           (eq (car form-or-symbol) 'function))))
+           (eq (car form-or-symbol) 'function)
+           (eq (car form-or-symbol) 'cl-function))))
+
+(defun loopy--quoted-symbol-p (form)
+  "Whether FORM is a quoted symbol."
+  (and (memq (car-safe form) '(quote function cl-function))
+       (symbolp (cl-second form))))
+
+(defun loopy--apply-function (func &rest args)
+  "Return an expansion that appropriately applies FUNC to ARGS.
+
+This expansion can apply FUNC directly or via `funcall'."
+  (if (loopy--quoted-form-p func)
+      `(,(loopy--get-function-symbol func) ,@args)
+    `(funcall ,func ,@args)))
+
+(defun loopy--quote-if-car-not-symbol-or-lambda (list)
+  "Apply a heuristic to decide if LIST should be quoted."
+  (if (or (symbolp (car-safe list))
+          (eq (car-safe list) 'lambda))
+      list
+    `(quote ,list)))
 
 (defun loopy--extract-main-body (instructions)
   "Extract main-body expressions from INSTRUCTIONS.
@@ -269,8 +326,29 @@ must sometimes create a sequence to be destructured."
                          collect (loopy--mimic-init-structure i val))
                 'array))))
 
+;; TODO: Would this be more useful as a `pcase' macro?
+(defmacro loopy--plist-bind (bindings plist &rest body)
+  "Destructure PLIST into BINDINGS, surrounding BODY.
+
+BINDINGS is of the form (KEY VAR KEY VAR ...).  VAR can be a list
+of two elements: a variable name and a default value, similar to
+what one would use for `cl-defun'.
+
+This function is similar in use to `cl-destructuring-bind'."
+  (declare (indent 2))
+  (let ((value-holder (gensym "plist-let-")))
+    `(let* ((,value-holder ,plist)
+            ,@(cl-loop for (key var . _) on bindings by #'cddr
+                       if (consp var)
+                       collect `(,(cl-first var)
+                                 (or (plist-get ,value-holder ,key)
+                                     ,(cl-second var)))
+                       else collect `(,var (plist-get ,value-holder ,key))))
+       ,@body)))
+
 ;;;; Included parsing functions.
 ;;;;; Misc.
+;;;;;; Sub Loop
 (cl-defun loopy--parse-sub-loop-command ((_ &rest body))
   "Parse the `loop' or `sub-loop' command.
 
@@ -387,6 +465,7 @@ BODY is one or more loop commands."
             non-wrapped-instructions))))
 
 ;;;;; Genereric Evaluation
+;;;;;; Expr
 (cl-defun loopy--parse-expr-command ((_ var &rest vals))
   "Parse the `expr' command.
 
@@ -448,6 +527,7 @@ BODY is one or more loop commands."
              needed-instructions)
           needed-instructions)))))
 
+;;;;;; Prev Expr
 (cl-defun loopy--parse-prev-expr-command ((_ var val &key init back))
   "Parse the `prev-expr' command as (prev-expr VAR VAL &key init back).
 
@@ -500,6 +580,7 @@ This command does not wait for VAL to change before updating VAR."
                                            for hv in holding-vars
                                            collect (list hv pvar)))))))))
 
+;;;;;; Group
 (cl-defun loopy--parse-group-command ((_ &rest body))
   "Parse the `group' loop command.
 
@@ -514,6 +595,7 @@ BODY is one or more commands to be grouped by a `progn' form."
     (cons `(loopy--main-body . (progn ,@(nreverse progn-body)))
           (nreverse full-instructions))))
 
+;;;;;; Do
 (cl-defun loopy--parse-do-command ((_ &rest expressions))
   "Parse the `do' loop command.
 
@@ -523,6 +605,7 @@ the loop literally (not even in a `progn')."
           expressions))
 
 ;;;;; Conditionals
+;;;;;; If
 (cl-defun loopy--parse-if-command
     ((_ condition &optional if-true &rest if-false))
   "Parse the `if' loop command.  This takes the entire command.
@@ -555,6 +638,7 @@ the loop literally (not even in a `progn')."
                 ,@(nreverse if-false-main-body)))
           (nreverse full-instructions))))
 
+;;;;;; Cond
 (cl-defun loopy--parse-cond-command ((_ &rest clauses))
   "Parse the `cond' command.  This works like the `cond' special form.
 
@@ -581,6 +665,7 @@ command are inserted into a `cond' special form."
     (cons `(loopy--main-body . ,(cons 'cond (nreverse actual-cond-clauses)))
           (nreverse full-instructions))))
 
+;;;;;; When Unless
 (cl-defun loopy--parse-when-unless-command ((name condition &rest body))
   "Parse `when' and `unless' commands.
 
@@ -599,96 +684,433 @@ command are inserted into a `cond' special form."
           (nreverse full-instructions))))
 
 ;;;;; Iteration
-(cl-defun loopy--parse-array-command ((_ var val))
-  "Parse the `array' command.
+(cl-defmacro loopy--defiteration
+    (name doc-string &key keywords (required-vals 1) other-vals instructions)
+  "Define an interation command parser for NAME.
 
-- VAR is a variable name.
-- VAL is an array value.
-- Optional VALUE-HOLDER holds the array value.
-- Optional INDEX-HOLDER holds the index value."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'array))
+An iteration command made with this macro has the layout of
+\(command-name variable-name value [values] [keys]).  That is,
+each command will always require a variable name and a value.
+Some commands will have additional non-keyword arguments, which
+will be either required or optional.  Some commands will have
+keyword arguments, which, as in functions, are always optional.
+
+Not all iteration loop commands are written using this macro.
+This macro is for iteration commands that have the above
+structure.
+
+- NAME is the primary name of the loop command.  This creates a
+  parsing function \"loopy--parse-NAME-command\".
+
+- DOC-STRING is the documentation string for the produced parsing
+  function.  It should describe the arguments of the loop command.
+
+- KEYWORDS is an unquoted list of colon-prefixed keywords used by
+  the command.
+
+- REQUIRED-VALS is the number of required values.  For most
+  iteration commands, this is one.  This can be one nil (or
+  zero), a non-zero number, or an unquoted list of variable
+  names.
+
+  If a list of variable names, those names are used in the
+  function definition.  Otherwise, the variables are named
+  following the naming scheme \"valNUM\".
+
+- OTHER-VALS is whether the command can take other arguments that
+  are not keyword arguments.  This is one of nil, t, or an
+  unquoted list of numbers.
+
+  If a list of numbers, then those numbers describe the valid
+  amounts of additional (non-keyword) arguments of the command.
+  For example, (0 1) means that command has 1 optional
+  non-keyword argument.  (1 3) means the command requires either
+  1 or 3 additional non-keyword arguments.
+
+  This means that if a command has no required arguments, but
+  several optional non-keyword arguments, you can set
+  REQUIRED-VALS to 0 and OTHER-VALS to a list of 0 and some
+  integer.
+
+  If t, no check if performed and the command takes any number of
+  optional additional arguments.
+
+- INSTRUCTIONS are the command's instructions.  This should be a
+  single expression, such as a list of instructions or an
+  expression capable of producing said instructions.
+
+In the expanded parsing function, there are several values
+automatically bound to variables, which can be used in
+instructions:
+
+- `name' is the name of the command.
+
+- `cmd' is the entire command expression.
+
+- `var' is the variable to be used by the command.
+
+- `val' is the required value (generally, the sequence over which
+  to iterate). If there are multiple required values, they are
+  instead named according to the value of REQUIRED-VALS.
+
+- `args' is a list of the remaining arguments of the command
+   after `var' and `val'.  If either OTHER-VALS or KEYWORDS are
+   nil, then this variable is not bound.  In that case, use the
+   below two variables.
+
+- `other-vals' is a list of additional values found in `args',
+   if OTHER-VALS is non-nil.
+
+- `opts' is a list of keyword arguments and their values,
+  found in `args' after the elements of `other-vals'.
+  It is assumed that this list can be treated as a property list.
+  The first keyword in `args' determines the start of
+  the optional keyword arguments.
+
+  If OTHER-VALS is non-nil (i.e., no other values are allowed),
+  then these keyword variables should be referenced directly
+  instead of through the property list `opts'."
+
+  (declare (indent defun) (doc-string 2))
+
+  ;; Make sure `keywords' is a list.
+  (when (nlistp keywords)
+    (setq keywords (list keywords)))
+
+  ;; Make sure `keywords' are all prefixed with a colon.
+  (setq keywords (mapcar (lambda (x)
+                           (if (eq ?: (aref (symbol-name x) 0))
+                               x
+                             (intern (format ":%s" x))))
+                         keywords))
+
+  ;; Check that `instructions' given.
+  (unless instructions
+    (error "Instructions required"))
+
+  ;; Store the variable names of the keyword arguments so we only have to
+  ;; compute them one.  E.g., "by" from ":by".
+  ;; Currently, keywords are required to be prefixed by the colon.
+  (let ((var-keys (when keywords
+                    (cl-loop for sym in keywords
+                             collect (intern (substring (symbol-name sym) 1))))))
+
+    `(cl-defun ,(intern (format "loopy--parse-%s-command" name))
+         (( &whole cmd name var
+            ,@(cond
+               ((eq 1 required-vals)
+                '(val))
+               ((or (eq required-vals nil)
+                    (eq required-vals 0))
+                nil)
+               ((consp required-vals)
+                required-vals)
+               ((integerp required-vals)
+                (cl-loop for i from 1 to required-vals
+                         collect (intern (format "val%d" i))))
+               (t
+                (error "Bad value for `required-vals': %s" required-vals)))
+            ,@(if keywords
+                  (if other-vals
+                      '(&rest args)
+                    `(&key ,@var-keys))
+                (when other-vals
+                  '(&rest other-vals)))))
+       ,doc-string
+
+       (when loopy--in-sub-level
+         (loopy--signal-bad-iter (quote ,name)))
+
+       (let* ,(if keywords
+                  (if other-vals
+                      '((other-vals nil)
+                        (opts nil))
+                    ;; These can be referred to directly, but we'll keep
+                    ;; the option open for using `opts'.
+                    `((opts (list ,@(cl-loop for sym in keywords
+                                             for var in var-keys
+                                             append (list sym var))))))
+                nil)
+
+         ;; We only want to run this code if the values of `opts' and
+         ;; `other-vals' are contained in `args'.  For other cases, the
+         ;; function arguments perform this step for us.
+         ,@(when (and other-vals keywords)
+             `(;; Set `opts' as starting from the first keyword and `other-vals'
+               ;; as everything before that.
+               (cl-loop with other-val-holding = nil
+                        for cons-cell on args
+                        for arg = (car cons-cell)
+                        until (keywordp arg)
+                        do (push arg other-val-holding)
+                        finally do (setq opts cons-cell
+                                         other-vals (nreverse other-val-holding)))
+
+               ;; Validate any keyword arguments:
+               (when (cl-set-difference (loopy--every-other opts)
+                                        (quote ,keywords))
+                 (error "Wrong number of arguments or wrong keywords: %s" cmd))))
+
+         ,(when (consp other-vals)
+            `(unless (cl-member (length other-vals)
+                                (quote ,other-vals)
+                                :test #'=)
+               (error "Wrong number of arguments or wrong keywords: %s" cmd)))
+
+         (ignore cmd name
+                 ;; We can only ignore variables if they're defined.
+                 ,(if other-vals 'other-vals)
+                 ,(if keywords 'opts))
+
+         ,instructions))))
+
+(defun loopy--find-start-by-end-dir-vals (plist)
+  "Find the numeric start, end, and step, direction, and inclusivity.
+
+The values are returned in a list in that order as a plist.
+
+PLIST contains the keyword arguments passed to a sequence
+iteration command.  The supported keywords are:
+
+- from, upfrom (inclusive)
+- downfrom (inclusive)
+- to, upto (inclusive)
+- downto (inclusive)
+- above (exclusive)
+- below (exclusive)"
+
+  (loopy--plist-bind ( :from from :upfrom upfrom :downfrom downfrom
+                       :to to :upto upto :downto downto
+                       :above above :below below
+                       :by by)
+      plist
+    ;; Check the inputs:
+    (when (or (< 1 (cl-count-if #'identity (list from upfrom downfrom)))
+              (< 1 (cl-count-if #'identity (list to upto downto above below)))
+              (and downfrom below)
+              (and upfrom above))
+      (error "Conflicting arguments: %s" plist))
+
+    (let ((decreasing (or downfrom downto above)))
+
+      ;; Check directions  for above and below.
+      ;; :above is only for when the value is decreasing.
+      ;; :below is only for when the value in increasing.
+      (when (or (and below decreasing)
+                (and above (not decreasing)))
+        (error "Conflicting arguments: %s" plist))
+
+      (list :start (or from upfrom downfrom)
+            :by by
+            :end (or to downto above below upto)
+            :decreasing decreasing
+            :inclusive (not (or above below))))))
+
+;;;;;; Array
+(defmacro loopy--distribute-array-elements (&rest arrays)
+  "Distribute the elements of the ARRAYS into an array of lists.
+
+For example, [1 2] and [3 4] gives [(1 3) (1 4) (2 3) (2 4)]."
+  (let ((vars (cl-loop for _ in arrays
+                       collect (gensym "array-var-")))
+        (reverse-order (reverse arrays)))
+    (cl-loop with expansion = `(cl-loop for ,(cl-first vars)
+                                        across ,(cl-first reverse-order)
+                                        do (setq result
+                                                 (cons (list ,@(reverse vars))
+                                                       result)))
+             for var in (cl-rest vars)
+             for array in (cl-rest reverse-order)
+             do (setq expansion `(cl-loop for ,var across ,array
+                                          do ,expansion))
+             finally return `(let ((result nil))
+                               ,expansion
+                               (vconcat (nreverse result))))))
+
+(loopy--defiteration array
+  "Parse the `array' command as (array VAR VAL [VALS] &key KEYS).
+
+KEYS is one or several of `:index', `:by', `:from', `:downfrom',
+`:upfrom', `:to', `:downto', `:upto', `:above', or `:below'.
+
+- `:index' names a variable used to store the accessed index of
+  the array.
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
+
+`:downto' and `:downfrom' make the index decrease instead of increase.
+
+If multiple values are given, their elements are distributed
+using the function `loopy--distribute-array-elements'."
+  :other-vals t
+  :keywords (:index
+             :by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :instructions
   (let ((value-holder (gensym "array-"))
-        (index-holder (gensym "array-index-"))
-        (length-holder (gensym "array-length-")))
-    `((loopy--iteration-vars . (,value-holder ,val))
-      (loopy--iteration-vars . (,index-holder 0))
-      (loopy--iteration-vars . (,length-holder (length ,value-holder)))
-      ,@(loopy--destructure-for-iteration-command var
-                                                  `(aref ,value-holder ,index-holder))
-      (loopy--latter-body    . (setq ,index-holder (1+ ,index-holder)))
-      (loopy--pre-conditions . (< ,index-holder ,length-holder)))))
+        (index-holder (or (plist-get opts :index)
+                          (gensym "array-index-")))
+        (end-holder (gensym "array-end-"))
+        (increment-holder (gensym "array-increment")))
 
-(cl-defun loopy--parse-array-ref-command ((_ var val))
-  "Parse the `array-ref' command by editing the `array' command's instructions.
+    (loopy--plist-bind ( :start key-start :end key-end :by (by 1)
+                         :decreasing decreasing :inclusive inclusive)
 
-VAR is a variable name.  VAL is an array value.  VALUE-HOLDER
-holds the array value.  INDEX-HOLDER holds the index value."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'array-ref))
-  (let ((value-holder (gensym "array-"))
-        (index-holder (gensym "array-ref-index-"))
-        (length-holder (gensym "array-ref-length-")))
-    `(,@(loopy--destructure-for-generalized-command
-         var `(aref ,value-holder ,index-holder))
-      (loopy--iteration-vars  . (,value-holder ,val))
-      (loopy--iteration-vars  . (,index-holder 0))
-      (loopy--iteration-vars . (,length-holder (length ,value-holder)))
-      (loopy--latter-body    . (setq ,index-holder (1+ ,index-holder)))
-      (loopy--pre-conditions . (< ,index-holder ,length-holder)))))
+        (loopy--find-start-by-end-dir-vals opts)
 
-(cl-defun loopy--parse-cons-command ((_ var val &optional (func #'cdr)))
-  "Parse the `cons' loop command.
+      `((loopy--iteration-vars . (,increment-holder ,by))
+        (loopy--iteration-vars
+         . (,value-holder ,(if (null other-vals)
+                               val
+                             `(loopy--distribute-array-elements
+                               ,val ,@other-vals))))
+        (loopy--iteration-vars . (,end-holder ,(or key-end
+                                                   (if decreasing
+                                                       -1
+                                                     `(length ,value-holder)))))
+        (loopy--iteration-vars . (,index-holder ,(or key-start
+                                                     (if decreasing
+                                                         `(1- (length ,value-holder))
+                                                       0))))
+        ,@(loopy--destructure-for-iteration-command
+           var `(aref ,value-holder ,index-holder))
+        (loopy--latter-body    . (setq ,index-holder (,(if decreasing #'- #'+)
+                                                      ,index-holder
+                                                      ,increment-holder)))
+        (loopy--pre-conditions . (,(if (or (null key-end)
+                                           (not inclusive))
+                                       (if decreasing #'> #'<)
+                                     (if decreasing #'>= #'<=))
+                                  ,index-holder ,end-holder))))))
 
-VAR is a variable name.  VAL is a cons cell value.  Optional FUNC
+;;;;;; Array Ref
+(loopy--defiteration array-ref
+  "Parse the `array-ref' command as (array-ref VAR VAL &key KEYS).
+
+KEYS is one or several of `:index', `:by', `:from', `:downfrom',
+`:upfrom', `:to', `:downto', `:upto', `:above', or `:below'.
+
+- `:index' names a variable used to store the accessed index of
+  the array.
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
+
+`:downto' and `:downfrom' make the index decrease instead of increase."
+  :keywords (:index :by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :instructions
+  (let ((value-holder (gensym "array-ref-"))
+        (index-holder (or (plist-get opts :index)
+                          (gensym "array-ref-index-")))
+        (end-holder (gensym "array-ref-end-"))
+        (increment-holder (gensym "array-ref-increment-")))
+
+    (loopy--plist-bind ( :start key-start :end key-end :by (by 1)
+                         :decreasing decreasing :inclusive inclusive)
+
+        (loopy--find-start-by-end-dir-vals opts)
+
+      `((loopy--iteration-vars . (,increment-holder ,by))
+        (loopy--iteration-vars . (,value-holder ,val))
+        (loopy--iteration-vars . (,end-holder ,(or key-end
+                                                   (if decreasing
+                                                       -1
+                                                     `(length ,value-holder)))))
+        (loopy--iteration-vars . (,index-holder ,(or key-start
+                                                     (if decreasing
+                                                         `(1- (length ,value-holder))
+                                                       0))))
+        ,@(loopy--destructure-for-generalized-command
+           var `(aref ,value-holder ,index-holder))
+        (loopy--latter-body    . (setq ,index-holder (,(if decreasing #'- #'+)
+                                                      ,index-holder
+                                                      ,increment-holder)))
+        (loopy--pre-conditions . (,(if (or (null key-end)
+                                           (not inclusive))
+                                       (if decreasing #'> #'<)
+                                     (if decreasing #'>= #'<=))
+                                  ,index-holder ,end-holder))))))
+
+;;;;;; Cons
+(loopy--defiteration cons
+  "Parse the `cons' loop command as (cons VAR VAL &key by).
+
+VAR is a variable name.  VAL is a cons cell value.  Keyword BY
 is a function by which to update VAR (default `cdr')."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'cons))
-  (if (symbolp var)
-      `((loopy--iteration-vars . (,var ,val))
+  :keywords (:by)
+  :instructions
+  (let ((value-holder (gensym "cons-")))
+    `((loopy--iteration-vars . (,value-holder ,val))
+      ,@(loopy--destructure-for-iteration-command var value-holder)
+      (loopy--latter-body
+       . (setq ,value-holder ,(loopy--apply-function (or by (quote #'cdr))
+                                                     value-holder)))
+      (loopy--pre-conditions . (consp ,value-holder)))))
+
+;;;;;; List
+(defmacro loopy--distribute-list-elements (&rest lists)
+  "Distribute the elements of LISTS into a list of lists.
+
+For example, (1 2) and (3 4) would give ((1 3) (1 4) (2 3) (2 4))."
+  (let ((vars (cl-loop for _ in lists
+                       collect (gensym "list-var-")))
+        (reverse-order (reverse lists)))
+    (cl-loop with expansion = `(dolist (,(cl-first vars)
+                                        ,(cl-first reverse-order))
+                                 (setq result (cons (list ,@(reverse vars))
+                                                    result)))
+             for var in (cl-rest vars)
+             for list in (cl-rest reverse-order)
+             do (setq expansion `(dolist (,var ,list)
+                                   ,expansion))
+             finally return `(let ((result nil))
+                               ,expansion
+                               (nreverse result)))))
+
+(loopy--defiteration list
+  "Parse the list command as (list VAR VAL [VALS] &key by).
+
+BY is function to use to update the list.  It defaults to `cdr'.
+
+If multiple values are given, their elements are distributed
+using the function `loopy--distribute-list-elements'."
+  :other-vals t
+  :keywords (:by)
+  :instructions
+  (let* ((by-func (or (plist-get opts :by)
+                      ;; Need to quote as if passed in to macro
+                      (quote #'cdr))))
+    (let ((value-holder (gensym "list-")))
+      `((loopy--iteration-vars
+         . (,value-holder ,(if (null other-vals)
+                               val
+                             `(loopy--distribute-list-elements
+                               ,val ,@other-vals))))
         (loopy--latter-body
-         . (setq ,var (,(loopy--get-function-symbol func) ,var)))
-        (loopy--pre-conditions . (consp ,var)))
-    ;; TODO: For destructuring, do we actually need the extra variable?
-    (let ((value-holder (gensym "cons-")))
-      `((loopy--iteration-vars . (,value-holder ,val))
-        ,@(loopy--destructure-for-iteration-command var value-holder)
-        (loopy--latter-body
-         . (setq ,value-holder (,(loopy--get-function-symbol func)
-                                ,value-holder)))
-        (loopy--pre-conditions . (consp ,value-holder))))))
+         . (setq ,value-holder ,(loopy--apply-function by-func value-holder)))
+        (loopy--pre-conditions . (consp ,value-holder))
+        ,@(loopy--destructure-for-iteration-command
+           var `(car ,value-holder))))))
 
-(cl-defun loopy--parse-list-command
-    ((_ var val &optional (func #'cdr)) &optional (val-holder (gensym "list-")))
-  "Parse the `list' loop command.
+;;;;;; List Ref
+(loopy--defiteration list-ref
+  "Parse the `list-ref' loop command as (list-ref VAR VAL &key by).
 
-VAR is a variable name or a list of such names (dotted pair or
-normal).  VAL is a list value.  FUNC is a function used to update
-VAL (default `cdr').  VAL-HOLDER is a variable name that holds
-the list."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'list))
-  `((loopy--iteration-vars . (,val-holder ,val))
-    (loopy--latter-body
-     . (setq ,val-holder (,(loopy--get-function-symbol func) ,val-holder)))
-    (loopy--pre-conditions . (consp ,val-holder))
-    ,@(loopy--destructure-for-iteration-command var `(car ,val-holder))))
+BY is the function to use to move through the list (default `cdr')."
+  :keywords (:by)
+  :instructions
+  (let ((val-holder (gensym "list-ref"))
+        ;; Need to quote as if passed in to macro
+        (by-func (or by (quote #'cdr))))
+    `((loopy--iteration-vars . (,val-holder ,val))
+      ,@(loopy--destructure-for-generalized-command var `(car ,val-holder))
+      (loopy--latter-body
+       . (setq ,val-holder ,(loopy--apply-function by-func val-holder)))
+      (loopy--pre-conditions . (consp ,val-holder)))))
 
-(cl-defun loopy--parse-list-ref-command
-    ((_ var val &optional (func #'cdr)) &optional (val-holder (gensym "list-ref-")))
-  "Parse the `list-ref' loop command, editing the `list' commands instructions.
-
-VAR is the name of a setf-able place.  VAL is a list value.  FUNC
-is a function used to update VAL (default `cdr').  VAL-HOLDER is
-a variable name that holds the list."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'list-ref))
-  `((loopy--iteration-vars . (,val-holder ,val))
-    ,@(loopy--destructure-for-generalized-command var `(car ,val-holder))
-    (loopy--latter-body . (setq ,val-holder (,(loopy--get-function-symbol func)
-                                             ,val-holder)))
-    (loopy--pre-conditions . (consp ,val-holder))))
-
+;;;;;; Map
 (cl-defun loopy--parse-map-command ((_ var val))
   "Parse the `map' loop command.
 
@@ -703,88 +1125,96 @@ vector using the library `map.el'."
       (loopy--pre-conditions . (consp ,value-holder))
       (loopy--latter-body . (setq ,value-holder (cdr ,value-holder))))))
 
-(cl-defun loopy--parse-nums-command ((&whole cmd _ var start &rest args))
-  "Parse the `nums' command as (nums VAR START [END] &key BY DOWN).
+;;;;;; Nums
+(loopy--defiteration nums
+  "Parse the `nums' command as (nums VAR [START [END]] &key KEYS).
 
-If END is given, end the loop when the value of VAR is greater
-than END.  BY is the positive value used to increment VAR from
-START to END.  IF DOWN is given, end the loop when the value of
-VAR is less than END."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'nums))
+- START is the starting index, if given.
+- END is the ending index (inclusive), if given.
 
-  ;; Verify args
-  (when args
-    (unless (and (if (keywordp (cl-first args))
-                     (cl-member (length args) '(2 4) :test #'=)
-                   (cl-member (length args) '(1 3 5) :test #'=))
-                 (loopy--valid-keywords-p '(:by :down)
-                                           (if (keywordp (cl-first args))
-                                               args
-                                             (cl-rest args))))
-      (error "Bad arguments to `nums': %s" cmd)))
+KEYS is one or several of `:index', `:by', `:from', `:downfrom',
+`:upfrom', `:to', `:downto', `:upto', `:above', or `:below'.
 
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
 
-  (let ((end (unless (keywordp (cl-first args))
-               (cl-first args))))
-    (let ((down (plist-get (if end (cdr args) args) :down))
-          (by   (plist-get (if end (cdr args) args) :by))
-          (increment-val-holder (gensym "nums-increment")))
+`:downto' and `:downfrom' make the index decrease instead of increase."
+  :keywords (:by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :required-vals 0
+  :other-vals (0 1 2)
+  :instructions
+  ;; TODO: `cl-destructuring-bind' signals error here.  Why?
+  (seq-let (explicit-start explicit-end) other-vals
 
-      `((loopy--iteration-vars . (,var ,start))
-        ,(when by
-           `(loopy--iteration-vars . (,increment-val-holder ,by)))
-        ,(when end
-           `(loopy--pre-conditions . (,(if down #'>= #'<=)
-                                      ,var ,end)))
-        (loopy--latter-body . (setq ,var ,(cond
-                                           (by   `(,(if down #'- #'+)
-                                                   ,var ,increment-val-holder))
-                                           (down `(1- ,var))
-                                           (t    `(1+ ,var)))))))))
+    (loopy--plist-bind ( :start key-start :end key-end :by (by 1)
+                         :decreasing decreasing :inclusive inclusive)
 
-(cl-defun loopy--parse-nums-up-command ((&whole cmd _ var start &rest args))
-  "Parse the `nums-up' command as (nums-up START [END] &key by)."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'nums-up))
+        (loopy--find-start-by-end-dir-vals opts)
 
-  (when args
-    (let ((end-given (not (keywordp (cl-first args)))))
-      (unless (and (if end-given
-                       (cl-member (length args) '(1 3) :test #'=)
-                     (= 2 (length args)))
-                   (loopy--valid-keywords-p '(:by)
-                                             (if end-given
-                                                 (cl-rest args)
-                                               args)))
-        (error "Bad arguments to `nums-up': %s" cmd))))
+      ;; Check that nothing conflicts.
+      (when (or (and explicit-start key-start)
+                (and explicit-end key-end))
+        (error "Conflicting commands given: %s" cmd))
 
-  (loopy--parse-loop-command `(nums ,var ,start ,@args)))
+      (let ((increment-val-holder (gensym "nums-increment"))
+            (end (or explicit-end key-end))
+            (end-val-holder (gensym "nums-end"))
+            (start (or explicit-start key-start 0)))
 
+        `((loopy--iteration-vars . (,var ,start))
+          (loopy--iteration-vars . (,increment-val-holder ,by))
+          ,@(when end
+              `((loopy--iteration-vars . (,end-val-holder ,end))
+                (loopy--pre-conditions . (,(if inclusive
+                                               (if decreasing #'>= #'<=)
+                                             (if decreasing #'> #'<))
+                                          ,var ,end-val-holder))))
+          (loopy--latter-body . (setq ,var ,(cond
+                                             (by   `(,(if decreasing #'- #'+)
+                                                     ,var ,increment-val-holder))
+                                             (decreasing `(1- ,var))
+                                             (t    `(1+ ,var))))))))))
 
-(cl-defun loopy--parse-nums-down-command ((&whole cmd _ var start &rest args))
-  "Parse the `nums-down' command as (nums-up START [END] &key by)."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'nums-up))
+;;;;;; Nums Up
+(loopy--defiteration nums-up
+  "Parse the `nums-up' command as (nums-up START [END] &key by).
 
-  (when args
-    (let ((end-given (not (keywordp (cl-first args)))))
-      (unless (and (if end-given
-                       (cl-member (length args) '(1 3) :test #'=)
-                     (= 2 (length args)))
-                   (loopy--valid-keywords-p '(:by)
-                                             (if end-given
-                                                 (cl-rest args)
-                                               args)))
-        (error "Bad arguments to `nums-down': %s" cmd))))
+This is for increasing indices.
 
-  (loopy--parse-loop-command `(nums ,var ,start ,@args :down t)))
+- START is the starting index.
+- END is the ending index (inclusive), if given.
+- BY is the step size."
+  :other-vals (0 1)
+  :keywords (:by)
+  :instructions
+  (loopy--plist-bind (:by by) opts
+    (loopy--parse-loop-command `(nums ,var ,val
+                                      :upto ,(car other-vals)
+                                      :by ,by))))
 
+;;;;;; Nums Down
+(loopy--defiteration nums-down
+  "Parse the `nums-down' command as (nums-up START [END] &key by).
 
+This is for decreasing indices.
+
+- START is the starting index.
+- END is the ending index (inclusive), if given.
+- BY is the step size.  Even though the index value is decreasing,
+  this should still be a positive value."
+  :other-vals (0 1)
+  :keywords (:by)
+  :instructions
+  (loopy--plist-bind (:by by) opts
+    (loopy--parse-loop-command `(nums ,var ,val
+                                      :downto ,(car other-vals)
+                                      :by ,by))))
+
+;;;;;; Repeat
 (cl-defun loopy--parse-repeat-command ((_ var-or-count &optional count))
-  "Parse the `repeat' loop command.
-
-The command can be of the form (repeat VAR  COUNT) or (repeat COUNT).
+  "Parse the `repeat' loop command as (repeat [VAR] VAL).
 
 VAR-OR-COUNT is a variable name or an integer.  Optional COUNT is
 an integer, to be used if a variable name is provided."
@@ -799,68 +1229,203 @@ an integer, to be used if a variable name is provided."
         (loopy--latter-body . (setq ,value-holder (1+ ,value-holder)))
         (loopy--pre-conditions . (< ,value-holder ,var-or-count))))))
 
-(cl-defun loopy--parse-seq-command ((_ var val))
-  "Parse the `seq' loop command.
+;;;;;; Seq
+(defmacro loopy--distribute-sequence-elements (&rest sequences)
+  "Distribute the elements of SEQUENCES into a vector of lists.
 
-VAR is a variable name.  VAL is a sequence value.  VALUE-HOLDER
-holds VAL.  INDEX-HOLDER holds an index that point into VALUE-HOLDER."
-  ;; NOTE: `cl-loop' just combines the logic for lists and arrays, and
-  ;;       just checks the type for each iteration, so we do that too.
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'seq))
+For example, [1 2] and (3 4) give [(1 3) (1 4) (2 3) (2 4)]."
+  (let ((vars (cl-loop for _ in sequences
+                       collect (gensym "seq-var-")))
+        (reverse-order (reverse sequences)))
+    (cl-loop with expansion = `(cl-loop for ,(cl-first vars)
+                                        being the elements of ,(cl-first reverse-order)
+                                        do (setq result
+                                                 (cons (list ,@(reverse vars))
+                                                       result)))
+             for var in (cl-rest vars)
+             for sequence in (cl-rest reverse-order)
+             do (setq expansion `(cl-loop for ,var being the elements of ,sequence
+                                          do ,expansion))
+             finally return `(let ((result nil))
+                               ,expansion
+                               (vconcat (nreverse result))))))
+
+(loopy--defiteration seq
+  "Parse the `seq' command as (seq VAR EXPR [EXPRS] &key KEYS).
+
+KEYS is one or several of `:index', `:by', `:from', `:downfrom',
+`:upfrom', `:to', `:downto', `:upto', `:above', or `:below'.
+
+- `:index' names a variable used to store the accessed index of
+  the sequence.
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
+
+`:downto' and `:downfrom' make the index decrease instead of increase.
+
+If multiple sequence values are given, their elements are
+distributed using the function `loopy--distribute-sequence-elements'."
+  :keywords (:index :by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :other-vals t
+  :instructions
   (let ((value-holder (gensym "seq-"))
-        (index-holder (gensym "seq-index-"))
-        (length-holder (gensym "seq-length-")))
-    `((loopy--iteration-vars . (,value-holder ,val))
-      (loopy--iteration-vars . (,index-holder 0))
-      (loopy--iteration-vars . (,length-holder (length ,value-holder)))
-      ,@(loopy--destructure-for-iteration-command
-         var `(if (consp ,value-holder)
-                  (pop ,value-holder)
-                (aref ,value-holder ,index-holder)))
-      (loopy--latter-body   . (setq ,index-holder (1+ ,index-holder)))
-      (loopy--pre-conditions
-       . (and ,value-holder (or (consp ,value-holder)
-                                (< ,index-holder ,length-holder)))))))
+        (index-holder (or (plist-get opts :index)
+                          (gensym "seq-index-")))
+        (end-index-holder (gensym "seq-end-index-"))
+        (increment-holder (gensym "seq-increment-")))
 
-(cl-defun loopy--parse-seq-index-command ((_ var val))
-  "Parse the `seq-index' command.
+    (loopy--plist-bind ( :start starting-index :end ending-index :by (by 1)
+                         :decreasing going-down :inclusive inclusive)
 
-VAR is a variable name.  VAL is an array value.
+        (loopy--find-start-by-end-dir-vals opts)
 
-This command does not support destructuring."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'seq-index))
-  (let ((value-holder (gensym "seq-index-val"))
+
+      `((loopy--iteration-vars . (,increment-holder ,by))
+        (loopy--iteration-vars
+         . (,value-holder ,(if other-vals
+                               `(loopy--distribute-sequence-elements
+                                 ,val ,@other-vals)
+                             val)))
+        (loopy--iteration-vars
+         . (,index-holder ,(or starting-index (if going-down
+                                                  `(1- (length ,value-holder))
+                                                0))))
+        (loopy--iteration-vars
+         . (,end-index-holder ,(or ending-index (if going-down
+                                                    -1
+                                                  `(length ,value-holder)))))
+        (loopy--latter-body . (setq ,index-holder (,(if going-down '- '+)
+                                                   ,index-holder
+                                                   ,increment-holder)))
+
+        ;; Optimize for the case of traversing from start to end, as done in
+        ;; `cl-loop'.  Currently, all other case use `elt'.
+        ,@(cond
+           ((and (not going-down)
+                 (= 1 by)
+                 (or (eql 0 starting-index)
+                     (null starting-index)))
+
+            `(,@(loopy--destructure-for-iteration-command
+                 var `(if (consp ,value-holder)
+                          (pop ,value-holder)
+                        (aref ,value-holder ,index-holder)))
+              (loopy--pre-conditions
+               . (and ,value-holder
+                      ,(if ending-index
+                           `(,(if inclusive #'<= #'<)
+                             ,index-holder ,end-index-holder)
+                         `(or (consp ,value-holder)
+                              (< ,index-holder ,end-index-holder)))))))
+
+           (t
+            `(,@(loopy--destructure-for-iteration-command
+                 var `(elt ,value-holder ,index-holder))
+              (loopy--pre-conditions . (,(if (or (null ending-index)
+                                                 (not inclusive))
+                                             (if going-down '> '<)
+                                           (if going-down '>= '<=))
+                                        ,index-holder
+                                        ,end-index-holder)))))))))
+
+;;;;;; Seq Index
+(loopy--defiteration seq-index
+  "Parse the `seq-index' command as (seq-index VAR VAL &key KEYS).
+
+KEYS is one or several of `:by', `:from', `:downfrom', `:upfrom',
+`:to', `:downto', `:upto', `:above', or `:below'.
+
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
+
+`:downto' and `:downfrom' make the index decrease instead of increase."
+
+  :keywords (:by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :instructions
+  (let ((value-holder (gensym "array-"))
+        (end-holder (gensym "array-end-"))
         (index-holder (gensym "seq-index-index-"))
-        (length-holder (gensym "seq-index-val-length-")))
-    `((loopy--iteration-vars . (,value-holder ,val))
-      (loopy--iteration-vars . (,index-holder 0))
-      (loopy--iteration-vars . (,length-holder (length ,value-holder)))
-      (loopy--iteration-vars . (,var nil))
-      (loopy--main-body . (setq ,var ,index-holder))
-      (loopy--latter-body    . (setq ,index-holder (1+ ,index-holder)))
-      (loopy--pre-conditions . (< ,index-holder ,length-holder)))))
+        (increment-holder (gensym "array-increment")))
 
-(cl-defun loopy--parse-seq-ref-command ((_ var val))
-  "Parse the `seq-ref' loop command.
+    (loopy--plist-bind ( :start key-start :end key-end :by (by 1)
+                         :decreasing decreasing :inclusive inclusive)
 
-VAR is a variable name.  VAL is a sequence value.  VALUE-HOLDER
-holds VAL.  INDEX-HOLDER holds an index that point into
-VALUE-HOLDER.  LENGTH-HOLDER holds than length of the value of
-VALUE-HOLDER, once VALUE-HOLDER is initialized."
-  (when loopy--in-sub-level
-    (loopy--signal-bad-iter 'seq-ref))
+        (loopy--find-start-by-end-dir-vals opts)
+
+      `((loopy--iteration-vars . (,var nil))
+        (loopy--iteration-vars . (,increment-holder ,by))
+        (loopy--iteration-vars . (,value-holder ,val))
+        (loopy--iteration-vars . (,end-holder ,(or key-end
+                                                   (if decreasing
+                                                       -1
+                                                     `(length ,value-holder)))))
+        (loopy--iteration-vars . (,index-holder ,(or key-start
+                                                     (if decreasing
+                                                         `(1- (length ,value-holder))
+                                                       0))))
+        (loopy--main-body      . (setq ,var ,index-holder))
+        (loopy--latter-body    . (setq ,index-holder (,(if decreasing #'- #'+)
+                                                      ,index-holder
+                                                      ,increment-holder)))
+        (loopy--pre-conditions . (,(if (or (null key-end)
+                                           (not inclusive))
+                                       (if decreasing #'> #'<)
+                                     (if decreasing #'>= #'<=))
+                                  ,index-holder ,end-holder))))))
+
+;;;;;; Seq Ref
+(loopy--defiteration seq-ref
+  "Parse the `seq' command as (seq VAR EXPR &key KEYS).
+
+KEYS is one or several of `:index', `:by', `:from', `:downfrom',
+`:upfrom', `:to', `:downto', `:upto', `:above', or `:below'.
+
+- `:index' names a variable used to store the accessed index of
+  the sequence.
+- `:by' is the increment step size as a positive value.
+- `:from', `:downfrom', and `:upfrom' name the starting index
+- `:to', `:downto', and `:upto' name the ending index (inclusive)
+- `:below' and `:above' name an exclusive ending index.
+
+`:downto' and `:downfrom' make the index decrease instead of increase."
+  :keywords (:index :by :from :downfrom :upfrom :to :downto :upto :above :below)
+  :instructions
   (let ((value-holder (gensym "seq-ref-"))
-        (index-holder (gensym "seq-ref-index-"))
-        (length-holder (gensym "seq-ref-length-")))
-    `((loopy--iteration-vars . (,value-holder ,val))
-      (loopy--iteration-vars . (,length-holder (length ,value-holder)))
-      (loopy--iteration-vars . (,index-holder 0))
-      ,@(loopy--destructure-for-generalized-command
-         var `(elt ,value-holder ,index-holder))
-      (loopy--latter-body   . (setq ,index-holder (1+ ,index-holder)))
-      (loopy--pre-conditions . (< ,index-holder ,length-holder)))))
+        (index-holder (or (plist-get opts :index)
+                          (gensym "seq-ref-index-")))
+        (end-index-holder (gensym "seq-ref-end-index-"))
+        (increment-holder (gensym "seq-ref-increment-")))
+
+    (loopy--plist-bind ( :start starting-index :end ending-index :by (by 1)
+                         :decreasing going-down :inclusive inclusive)
+
+        (loopy--find-start-by-end-dir-vals opts)
+
+      `((loopy--iteration-vars . (,increment-holder ,by))
+        (loopy--iteration-vars . (,value-holder ,val))
+        (loopy--iteration-vars
+         . (,index-holder ,(or starting-index (if going-down
+                                                  `(1- (length ,value-holder))
+                                                0))))
+        (loopy--iteration-vars
+         . (,end-index-holder ,(or ending-index (if going-down
+                                                    -1
+                                                  `(length ,value-holder)))))
+        (loopy--latter-body . (setq ,index-holder (,(if going-down '- '+)
+                                                   ,index-holder
+                                                   ,increment-holder)))
+        ,@(loopy--destructure-for-generalized-command
+           var `(elt ,value-holder ,index-holder))
+        (loopy--pre-conditions . (,(if (or (null ending-index)
+                                           (not inclusive))
+                                       (if going-down '> '<)
+                                     (if going-down '>= '<=))
+                                  ,index-holder
+                                  ,end-index-holder))))))
 
 (defun loopy--accumulation-starting-value (command-name)
   "Get the appropriate starting value for COMMAND-NAME."
@@ -984,7 +1549,13 @@ you can use in the instructions:
 
                (ignore var val)
                (if (sequencep var)
-                   (loopy--parse-destructuring-accumulation-command cmd)
+                   ;; If we need to destructure the sequence `var', we use the
+                   ;; function named by
+                   ;; `loopy--destructuring-accumulation-parser' or the function
+                   ;; `loopy--parse-destructuring-accumulation-command'.
+                   (funcall (or loopy--destructuring-accumulation-parser
+                                #'loopy--parse-destructuring-accumulation-command)
+                            cmd)
                  ;; Substitute in the instructions.
                  ,explicit)))
             (t
@@ -1025,6 +1596,7 @@ the inputs to test."
                      (cl-return y)))))
         `(cl-member x ,var :test ,test))))
 
+;;;;;; Accumulate
 (loopy--defaccumulation accumulate
   "Parse the `accumulate command' as (accumulate VAR VAL FUNC &key init)."
   :keywords (init)
@@ -1044,6 +1616,7 @@ the inputs to test."
                                                       ,val ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Adjoin
 (loopy--defaccumulation adjoin
   "Parse the `adjoin' command as (adjoin VAR VAL &key test key result-type at)
 
@@ -1116,6 +1689,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                                                         result-type))))))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Append
 (loopy--defaccumulation append
   "Parse the `append' command as (append VAR VAL &key at)."
   :keywords (at)
@@ -1152,6 +1726,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                     (error "Bad `:at' position: %s" cmd))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Collect
 (loopy--defaccumulation collect
   "Parse the `collect' command as (collect VAR VAL &key result-type at)."
   :keywords (result-type at)
@@ -1209,6 +1784,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                    (error "Bad `:at' position: %s" cmd))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Concat
 (loopy--defaccumulation concat
   "Parse the `concat' command as (concat VAR VAL &key at)."
   :keywords (at)
@@ -1241,6 +1817,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                                     (error "Bad `:at' position: %s" cmd)))))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Count
 (loopy--defaccumulation count
   "Parse the `count' command as (count VAR VAL)."
   ;; This is same as implicit behavior, so we only need to specify the explicit.
@@ -1249,6 +1826,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
               (loopy--main-body . (if ,val (setq ,var (1+ ,var))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Find
 (loopy--defaccumulation find
   "Parse a command of the form `(finding EXPR TEST &key ON-FAILURE)'."
   :num-args 3
@@ -1284,6 +1862,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                      . (,var . (if ,var nil (setq ,var ,on-failure)))))
                 (loopy--implicit-return   . ,var))))
 
+;;;;;; Max
 (loopy--defaccumulation max
   "Parse the `max' command as (max VAR VAL)."
   :explicit `((loopy--accumulation-vars
@@ -1291,6 +1870,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
               (loopy--main-body . (setq ,var (max ,val ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Min
 (loopy--defaccumulation min
   "Parse the `min' command as (min VAR VAL)."
   :explicit `((loopy--accumulation-vars
@@ -1298,6 +1878,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
               (loopy--main-body . (setq ,var (min ,val ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Multiply
 (loopy--defaccumulation multiply
   "Parse the `multiply' command as (multiply VAR VAL)."
   :explicit `((loopy--accumulation-vars
@@ -1305,6 +1886,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
               (loopy--main-body . (setq ,var (* ,val ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Nconc
 (loopy--defaccumulation nconc
   "Parse the `nconc' command as (nconc VAR VAL &key at)."
   :keywords (at)
@@ -1335,6 +1917,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                     (error "Bad `:at' position: %s" cmd))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Nunion
 (loopy--defaccumulation nunion
   "Parse the `nunion' command as (nunion VAR VAL &key test key at)."
   :keywords (test key at)
@@ -1366,6 +1949,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                       (error "Bad `:at' position: %s" cmd)))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Prepend
 (loopy--defaccumulation prepend
   "Parse the `prepend' command as (prepend VAR VAL)."
   :explicit `((loopy--accumulation-vars
@@ -1380,6 +1964,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
                                                     ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Push Into
 (loopy--defaccumulation push-into
   "Parse the `push' command as (push VAR VAL)."
   :explicit `((loopy--accumulation-vars
@@ -1387,6 +1972,7 @@ RESULT-TYPE can be used to `cl-coerce' the return value."
               (loopy--main-body . (setq ,var (cons ,val  ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Reduce
 (loopy--defaccumulation reduce
   "Parse the `reduce' command as (reduce VAR VAL FUNC &key init).
 
@@ -1408,6 +1994,7 @@ With INIT, initialize VAR to INIT.  Otherwise, VAR starts as nil."
                                         (funcall ,(cl-third args) ,var ,val)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Sum
 (loopy--defaccumulation sum
   "Parse the `sum' command as (sum VAR VAL)."
   ;; This is same as implicit behavior, so we only need to specify the explicit.
@@ -1416,6 +2003,7 @@ With INIT, initialize VAR to INIT.  Otherwise, VAR starts as nil."
               (loopy--main-body . (setq ,var (+ ,val ,var)))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Union
 (loopy--defaccumulation union
   "Parse the `union' command as (union VAR VAL &key test key at)."
   :keywords (test key at)
@@ -1447,6 +2035,7 @@ With INIT, initialize VAR to INIT.  Otherwise, VAR starts as nil."
                       (error "Bad `:at' position: %s" cmd)))))
               (loopy--implicit-return . ,var)))
 
+;;;;;; Vconcat
 (loopy--defaccumulation vconcat
   "Parse the `vconcat' command as (vconcat VAR VAL &key at)."
   :keywords (at)
@@ -1480,7 +2069,8 @@ With INIT, initialize VAR to INIT.  Otherwise, VAR starts as nil."
               (loopy--implicit-return . ,var)))
 
 
-;;;; Boolean Commands
+;;;;; Boolean Commands
+;;;;;; Always
 (cl-defun loopy--parse-always-command ((_ condition &rest other-conditions))
   "Parse a command of the form `(always CONDITION [CONDITIONS])'.
 
@@ -1503,6 +2093,7 @@ or t if the command is never evaluated."
 			    (unless ,return-val
 			      (cl-return-from ,loopy--loop-name nil)))))))
 
+;;;;;; Never
 (cl-defun loopy--parse-never-command ((_ condition &rest other-conditions))
   "Parse a command of the form `(never CONDITION [CONDITIONS])'.
 
@@ -1521,11 +2112,13 @@ Otherwise, `loopy' should return t."
                                    condition)
                             (cl-return-from ,loopy--loop-name nil))))))
 
+;;;;;; Thereis
 (cl-defun loopy--parse-thereis-command ((_ condition &rest other-conditions))
-  "Parse the `thereis' command as (thereis CONDITION [CONDITIONS]).'
+  "Parse the `thereis' command as (thereis CONDITION [CONDITIONS]).
 
-If any condition is non-nil, its value is immediately returned and the loop is exited.
-Otherwise the loop continues and nil is returned."
+If any condition is non-nil, its value is immediately returned
+and the loop is exited.  Otherwise the loop continues and nil is
+returned."
   (let ((value-holder (gensym "thereis-var-")))
     `((loopy--implicit-return  . nil)
       (loopy--main-body
@@ -1536,6 +2129,7 @@ Otherwise the loop continues and nil is returned."
 
 
 ;;;;; Exiting and Skipping
+;;;;;; Early Exit
 (cl-defun loopy--parse-early-exit-commands ((&whole command name &rest args))
   "Parse the  `return' and `return-from' loop commands.
 
@@ -1564,16 +2158,19 @@ a loop name, return values, or a list of both."
                   ((= 2 arg-length) (cl-second args))
                   (t                `(list ,@(cl-rest args))))))))))))
 
+;;;;;; Leave
 (cl-defun loopy--parse-leave-command (_)
   "Parse the `leave' command."
   '((loopy--tagbody-exit-used . t)
     (loopy--main-body . (go loopy--non-returning-exit-tag))))
 
+;;;;;; Skip
 (cl-defun loopy--parse-skip-command (_)
   "Parse the `skip' loop command."
   '((loopy--skip-used . t)
     (loopy--main-body . (go loopy--continue-tag))))
 
+;;;;;; While Until
 (cl-defun loopy--parse-while-until-commands ((name condition &rest conditions))
   "Parse the `while' and `until' commands.
 

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.5
+;; Version: 0.5.2
 ;; Package-Requires: ((emacs "25.1") (loopy "0.5") (dash "2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
@@ -140,7 +140,8 @@ For accumulation, we don't want Dash to assign to the named
     (array
      (cl-map 'vector #'loopy-dash--transform-var-list var-list))))
 
-(cl-defun loopy-dash--parse-destructuring-accumulation-command ((name var val))
+(cl-defun loopy-dash--parse-destructuring-accumulation-command
+    ((name var val &rest args))
   "Parse the accumulation loop commands, like `collect', `append', etc.
 
 NAME is the name of the command.  VAR-OR-VAL is a variable name
@@ -172,7 +173,7 @@ should only be used if VAR-OR-VAL is a variable."
       ;; and the explicitly named accumulation vars.
       ,@(mapcan (-lambda ((given-var . dash-copy))
                   (loopy--parse-loop-command
-                   (list name given-var dash-copy)))
+                   `(,name ,given-var ,dash-copy ,@args)))
                 loopy-dash--accumulation-destructured-symbols))))
 
 (provide 'loopy-dash)

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -317,7 +317,7 @@ These expressions can have loop commands in the body."
      ,@(loopy-iter--replace-in-tree (cddr tree))))
 
 (cl-defun loopy-iter--replace-in-sub-loop-command (tree)
-  "Replace loop commands in the `sub-loop' command.
+  "Replace loop commands in the `sub-loop' command TREE.
 
 Unlike in `loopy', this allows arbitrary expressions."
   (let ((loopy--in-sub-level nil)

--- a/loopy-pcase.el
+++ b/loopy-pcase.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.5
+;; Version: 0.5.2
 ;; Package-Requires: ((emacs "25.1") (loopy "0.5"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
@@ -98,7 +98,7 @@ Returns a list.  The elements are:
                 (cons var
                       (lambda (varvals &rest _)
                         (cons 'setq (mapcan (cl-function
-                                             (lambda ((var val &rest _))
+                                             (lambda ((var val &rest rest))
                                                (push var var-list)
                                                (list var val)))
                                             varvals))))))
@@ -131,7 +131,8 @@ Returns a list of two elements:
 2. A new list of bindings."
   (list 'pcase-let* bindings))
 
-(cl-defun loopy-pcase--parse-destructuring-accumulation-command ((name var val))
+(cl-defun loopy-pcase--parse-destructuring-accumulation-command
+    ((name var val &rest args))
   "Parse the accumulation loop command using `pcase' for destructuring.
 
 NAME is the name of the command.  VAR-OR-VAL is a variable name
@@ -153,7 +154,7 @@ should only be used if VAR-OR-VAL is a variable."
                               (seq-let (main-body other-instructions)
                                   (loopy--extract-main-body
                                    (loopy--parse-loop-command
-                                    (list name destr-var destr-val)))
+                                    `(,name ,destr-var ,destr-val ,@args)))
                                 ;; Just push the other instructions, but
                                 ;; gather the main body expressions.
                                 (dolist (instr other-instructions)
@@ -182,7 +183,7 @@ should only be used if VAR-OR-VAL is a variable."
                                   (seq-let (main-body other-instructions)
                                       (loopy--extract-main-body
                                        (loopy--parse-loop-command
-                                        (list name destr-var destr-val)))
+                                        `(,name ,destr-var ,destr-val ,@args)))
                                     ;; Just push the other instructions, but
                                     ;; gather the main body expressions.
                                     (dolist (instr other-instructions)

--- a/loopy-seq.el
+++ b/loopy-seq.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.5
+;; Version: 0.5.2
 ;; Package-Requires: ((emacs "25.1") (loopy "0.5"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
@@ -142,7 +142,8 @@ Returns a list.  The elements are:
    need to be `let'-bound."
   (loopy-pcase--destructure-for-iteration (seq--make-pcase-patterns var) val))
 
-(cl-defun loopy-seq--parse-destructuring-accumulation-command ((name var val))
+(cl-defun loopy-seq--parse-destructuring-accumulation-command
+    ((name var val &rest args))
   "Destructure an accumulation loop command as if by `seq-let'.
 
 NAME is the command name.  VAR is the variable sequence.  VAL is
@@ -158,7 +159,7 @@ the value to accumulate."
   ;; produce some instructions ourselves.
   `(,@(cl-remove-if (lambda (x) (eq (car-safe x) 'loopy--implicit-return))
                     (loopy-pcase--parse-destructuring-accumulation-command
-                     (list name (seq--make-pcase-patterns var) val)))
+                     `(,name ,(seq--make-pcase-patterns var) ,val ,@args)))
     ,@(mapcar (lambda (var) `(loopy--implicit-return . ,var))
               (loopy-seq--get-variables var))))
 

--- a/loopy.el
+++ b/loopy.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.5
+;; Version: 0.5.2
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
@@ -796,7 +796,7 @@ The function creates quoted code that should be used by a macro."
 (cl-defmacro loopy (&rest body)
   "A looping macro.
 
-The macro takes several top-level arguments, all, except a loop
+The macro takes several top level arguments, all, except a loop
 name, being a list beginning with one of the keywords below.  To
 name a loop, pass in an unquoted symbol as an argument.
 
@@ -832,11 +832,9 @@ Finally, `(finally-return 1 2 3)' is the same as
 `(finally-return (list 1 2 3))'.  This is convenient when using
 `seq-let', `pcase-let', `cl-destructuring-bind', and the like.
 
-Any another argument is assumed to be a loop command.  For more
-information, including a list of available loop commands, see the
-Info node `(loopy)' distributed with this package.
-
-\(fn COMMAND...)"
+Any other argument in BODY is assumed to be a loop command.  For
+more information, including a list of available loop commands,
+see the Info node `(loopy)' distributed with this package."
 
   (declare (debug (&rest ;; TODO: Is this correct?
                    [&or

--- a/tests/pcase-tests.el
+++ b/tests/pcase-tests.el
@@ -100,3 +100,17 @@
                                      (list (a . b)
                                            '((1 . 2) (3 . 4) (5 . 6)))
                                      (finally-return a b)))))))
+
+(ert-deftest pcase-accum-keywords ()
+  (should (equal '(((1 . 2)) ((1 . 1) (2 . 3)))
+                 (loopy (flag pcase)
+                        (list i '([(1 . 2) (1 . 1)]
+                                  [(1 . 2) (2 . 3)]))
+                        (adjoin `[,a1 ,a2] i :test #'equal)
+                        (finally-return a1 a2))))
+
+  (should (equal '((3 1) (4 2))
+                 (loopy (flag pcase)
+                        (list j '([1 2] [3 4]))
+                        (collect `[,c1 ,c2] j :at start)
+                        (finally-return c1 c2)))))

--- a/tests/seq-tests.el
+++ b/tests/seq-tests.el
@@ -97,7 +97,22 @@
 
 (ert-deftest seq-flag-enable-disable ()
   (should (equal '(5 6)
-                  (eval (quote (loopy (flag seq -seq)
-                                      (list (a . b)
-                                            '((1 . 2) (3 . 4) (5 . 6)))
-                                      (finally-return a b)))))))
+                 (eval (quote (loopy (flag seq -seq)
+                                     (list (a . b)
+                                           '((1 . 2) (3 . 4) (5 . 6)))
+                                     (finally-return a b)))))))
+
+;; Need to test accumulation commands of more than 2 arguments.
+(ert-deftest seq-accum-keywords ()
+  (should (equal '(((1 . 2)) ((1 . 1) (2 . 3)))
+                 (loopy (flag seq)
+                        (list i '([(1 . 2) (1 . 1)]
+                                  [(1 . 2) (2 . 3)]))
+                        (adjoin [a1 a2] i :test #'equal)
+                        (finally-return a1 a2))))
+
+  (should (equal '((3 1) (4 2))
+                 (loopy (flag seq)
+                        (list j '([1 2] [3 4]))
+                        (collect [c1 c2] j :at start)
+                        (finally-return c1 c2)))))


### PR DESCRIPTION
This PR addresses #65.

**WORK IN PROGRESS**

- Add macro to simplify definitions, similar in use to `loopy-defaccumulation`.
  - Add support for optional arguments and keyword arguments.
- Add distributing elements of multiple sequences.
  - TODO: What is the best data type for iterating through sequences?  We can
    choose what to make the sequence resulting from distribution.
- Try to add equivalent keywords for Iterate's sequence drivers.
- Make command arguments more regular.  For example, I haven't checked
  distributing elements for commands like `list-ref`, but it's still a good idea
  to change its optional `FUNC` argument to `:by`, to be more like the command
  `list`, for which an optional `FUNC` argument is no longer possible.