### PR TITLE
Add a `wrap` special macro argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 This document describes the user-facing changes to Loopy.
 
+
 ## Unreleased
+
+No changes so far.
+
+## 0.6.1
 
 ### Breaking Changes
 
@@ -24,6 +29,13 @@ This document describes the user-facing changes to Loopy.
 - The positional arguments of the `nums` command are now optional, and can be
   supplemented with keyword from the list above. ([#73])
 - Re-arrange documentation.
+
+### Bug Fixes
+
+- Fix using variables for the new `by` argument of the commands `list-ref`,
+  `list`, and `cons`.  This argument can now be a variable, which means that
+  references to function symbols must now be quoted ([#73]).
+
 
 [#65]: https://github.com/okamsn/loopy/issues/65
 [#73]: https://github.com/okamsn/loopy/pull/73

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -196,11 +196,12 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   :END:
 
   #+cindex: special macro argument
-  There are 7 special macro arguments. One, an unquoted symbol, is taken as the
-  loop's name. The others, listed below, are symbolic expressions that begin
-  with a keyword or one of their aliases. You do not need to use all of them.
+  There are only a few special macro arguments. One, an unquoted symbol, is
+  taken as the loop's name. The others, listed below, are symbolic expressions
+  that begin with a keyword or one of their aliases. You do not need to use all
+  of them.
 
-  If a macro argument does not match one of these special 7, ~loopy~ will
+  If a macro argument does not match one of these special few, ~loopy~ will
   attempt to interpret it as a loop command, and throw an error if that fails.
 
   These special macro arguments are always processed before loop commands,
@@ -341,6 +342,36 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
              ...)
     #+end_src
 
+  #+findex: wrap
+  - =wrap= :: A list of forms in which to wrap the loop itself (i.e., not
+    =before-do=, =after-do=, or anything else).  Each form can be either a list
+    or a symbol.  If a list, the loop is inserted into the end of the list.  If
+    a symbol, it is first converted to a list of 1 element before inserting the
+    loop at the end of the list.  This special macro argument is similar in use
+    to the Emacs Lisp macro ~thread-last~, except that forms listed first are
+    applied last, as in normal Lisp code.
+
+    The main difference between using this macro argument instead of just
+    writing the function calls normally is that these forms can access variables
+    initialized by the macro and that they occur after the code in =before-do=
+    is run.
+
+    #+begin_src emacs-lisp
+      (loopy (wrap (let ((a 1)))
+                   save-match-data)
+             ...)
+
+      ;; Similar to
+      (let ((a 1))
+        (save-match-data
+          (loopy ...)))
+
+      ;; => 6
+      (loopy (with (a 1))
+             (before-do (cl-incf a 2))
+             (wrap (progn (setq a (* 2 a))))
+             (return a))
+    #+end_src
 
   As stated above, all other expressions will be considered loop commands
   ([[#loop-commands][Loop Commands]]).

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -113,8 +113,7 @@ list.  For example, by default, \"(for collect i)\" and
 
 ;;;;
 (defvar loopy-iter--valid-macro-arguments
-  '( flag flags with init without no-init no-with before-do before initially-do
-     initially after-do after else-do else finally-do finally finally-return)
+  (remq 'let* loopy--valid-macro-arguments)
   "List of valid keywords for `loopy-iter' macro arguments.
 
 This variable is used to signal an error instead of silently failing.")
@@ -523,6 +522,10 @@ information on how to use `loopy' and `loopy-iter'.
    ;; Without
    (setq loopy--without-vars
          (loopy--find-special-macro-arguments '(without no-init) body))
+
+   ;; Wrap
+   (setq loopy--wrapping-forms
+         (loopy--find-special-macro-arguments '(wrap) body))
 
    ;; Before do
    (setq loopy--before-do

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -128,6 +128,28 @@
                                    (after-do (cl-incf i))
                                    (finally-return i)))))))
 
+;;;; Wrap
+
+(ert-deftest wrap ()
+  ;; Test saving match data
+  (should
+   (save-match-data
+     (let ((original-data (set-match-data nil)))
+       (equal original-data
+              (eval (quote (loopy (wrap save-match-data)
+                                  (repeat 1)
+                                  (do (string-match (make-string 100 ?a)
+                                                    (make-string 100 ?a)))
+                                  (finally-return (match-data)))))))))
+
+  ;; Test order things wrapped in.
+  (should (= 3 (eval (quote (loopy (wrap (let ((a 1)))
+                                         (let ((b (1+ a)))))
+                                   (return (+ a b)))))))
+
+  ;; TODO: Test `lambda' forms.
+  )
+
 ;;;; Final Instructions
 (ert-deftest finally-do ()
   (should (and (= 10


### PR DESCRIPTION
This special argument works similarly to `thread-last`, but applies its
arguments in the normal Lisp order (first item goes on the outside).


- Add and document the `wrap` special macro argument.
- Remove the number of special macro arguments from the documentation.  The
  count isn't important, and is just another thing to remember to change.