### PR TITLE
Clean up some of the code.

### DIFF
--- a/tests/tests.el
+++ b/tests/tests.el
@@ -1362,7 +1362,13 @@ implicit variable without knowing it's name, even for named loops."
   (should (equal '((3 1) (4 2))
                  (eval (quote (loopy (list i '((1 2) (3 4)))
                                      (accumulate (accum1 accum2) i #'cons
-                                                 :init nil)))))))
+                                                 :init nil))))))
+
+  (should (equal '((3 1) (4 2))
+                 (eval (quote (let ((f #'cons))
+                                (loopy (list i '((1 2) (3 4)))
+                                       (accumulate (accum1 accum2) i f
+                                                   :init nil))))))))
 
 ;;;;; Adjoin
 (ert-deftest adjoin ()


### PR DESCRIPTION
- Update parsing functions to use newer features, such as `loopy--plist-bind`
  and `loopy--extract-main-body`.
  - `group`
  - `if`
  - `when` and `unless`
  - `loopy--get-union-test-method`
  - `accumulate`
  - `adjoin`
  - `reduce`
  - `adjoin`
  - `collect`
  - `concat`
  - `nconc`
  - `nunion`
  - `reduce`
  - `union`
  - `vconcat`
  - `cond`

- Re-organize section Helpful Functions in `loopy-commands.el`.

- Remove function `loopy--accumulation-starting-value`.

  This function was used when alternative destructuring systems were producing
  their own instructions for accumulation commands, and so needed a way to know
  the correct initial values for a variable.  Currently, said systems just
  feed the destructured values to the actual command parser (e.g.,
  `loopy--parse-collect-command`).

- Split `loopy--parse-early-exit-commands` into separate parsers.
  - Create `loopy--parse-return-command`.
  - Create `loopy--parse-return-from-command`.