### PR TITLE
Improve accumulation command correctness. Fix some things.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This document describes the user-facing changes to Loopy.
 
 ## Unreleased
 
-## 0.6.1
-
 ### Breaking Changes
 
 - Previously, some commands (`accumulate`, `cons`) required using a function
@@ -20,6 +18,23 @@ This document describes the user-facing changes to Loopy.
 
 - Correctly `let`-bind `loopy--destructuring-for-iteration-function`.
   Previously, some destructuring settings would affect the next macro run.
+
+- `append` now appends to the ends of explicit accumulation variables
+  without copying first.  It is now much faster. [#78]
+
+- The accumulation commands which build lists (`adjoin`, `append`, `collect`,
+  `union`, `nonc`, `nunion`) are now more correct, at the cost of some speed
+  ([#78]).
+  - When adding the end of the list, variables explicitly named can now be
+    better modified during the loop.
+  - Accumulation commands can now better modify the end of the list
+    `loopy-result`.  Using implicit variables is still faster than using
+    explicit variables.
+  - Accumulation loop commands are now even more efficient when using the
+    `split` flag.  This is the fastest method to use build a result.
+
+- A more informative error is signaled when incompatible accumulation commands
+  are used ([#78]), showing the commands themselves.
 
 ## 0.6.1
 
@@ -53,3 +68,4 @@ This document describes the user-facing changes to Loopy.
 
 [#65]: https://github.com/okamsn/loopy/issues/65
 [#73]: https://github.com/okamsn/loopy/pull/73
+[#78]: https://github.com/okamsn/loopy/pull/78

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1412,11 +1412,11 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
    #+end_src
 
    Like in ~cl-loop~, all accumulation commands using implied variables will
-   accumulate into the same implied variable (that is, into ~loopy-result~).
-   You should make sure that such commands are compatible.  For example, you
-   should not try to accumulate =collect= results and =sum= results into
-   ~loopy-result~, as trying to use a list as a number will cause an error.  If
-   you want to collect into separate variables, just specify a variable name
+   accumulate into the same implied variable (that is, into ~loopy-result~).  An
+   error will be signaled if the accumulation commands are not compatible.  For
+   example, you should not try to accumulate =collect= results and =sum= results
+   into ~loopy-result~, as trying to use a list as a number will cause an error.
+   If you want to collect into separate variables, just specify a variable name
    like you normally would.
 
    #+attr_texinfo: :tag Warning
@@ -1460,6 +1460,40 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
             (collect i)        ; Without the `split' flag,
             (collect j)        ; this would just produce
             (collect k))       ; (1 2 3 4 5 6).
+   #+end_src
+
+   To be clear, the more guarantees that can be made about the accumulation
+   variables, the more ~loopy~ can optimize the accumulations.  The fastest
+   accumulations (from greatest speed to least), are produced by:
+   1. Using implied result variables with the =split= flag enabled.
+   2. Using the implied variable ~loopy-result~, which, similar to the variables
+      in (1), cannot be modified during the loop except by other accumulation
+      commands.  This is the default behavior for accumulation commands that do
+      not name a variable, and occurs when the =split= flag is disabled.
+   3. Using explicitly named result variables, which can be modified during the
+      loop by arbitrary code, not just accumulation commands.  This includes the
+      explicitly named variables required for destructuring.
+
+   Effort has gone into making each case efficient while keeping flexibility and
+   correctness.  The difference in speed can be significant when working with
+   large sequences or performing many accumulations.
+
+   #+begin_src emacs-lisp
+     ;; This is the slowest form.
+     ;; => (1 2 3)
+     (loopy (list i '(1 2 3))
+            (collect my-collection i)
+            (finally-return my-collection))
+
+     ;; Accumulations with implicit variables are faster.
+     ;; => (1 2 3)
+     (loopy (list i '(1 2 3))
+            (collect i))
+
+     ;; Accumulations with split implicit variables are fastest.
+     (loopy (flag split)
+            (list i '(1 2 3))
+            (collect i))
    #+end_src
 
    #+attr_texinfo: :tag Note

--- a/loopy.el
+++ b/loopy.el
@@ -6,7 +6,7 @@
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
 ;; Version: 0.6.1
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "27.1") (map "3.0"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 
@@ -250,6 +250,26 @@ Unlike in `loopy--iteration-vars', these variables should be
 accessible from anywhere in the macro, and should not be reset
 for sub-loops.")
 
+(defvar loopy--accumulation-list-end-vars nil
+  "Associations of accumulation variables and variables pointing to their ends.
+
+Keys are symbols naming variables.  Values are symbols naming variables.
+
+When working with lists, it is useful to be able to reference the
+last link in the list.  This makes appending to the end of the
+list much easier.  When using multiple accumulation commands, it
+is important that such commands use the same variable to keep
+track of the end of the list.")
+
+(defvar loopy--accumulation-variable-info nil
+  "Information about accumulation variables to ensure command compatibility.
+
+Information is of the form (VARIABLE-NAME CATEGORY COMMAND).
+Current categories are `list', `string', `vector', `value', and
+`reverse-list'.
+
+See `loopy--check-accumulation-compatibility' for more.")
+
 (defvar loopy--wrapping-forms nil
   "Forms that should wrap the loop body, applied in order.
 
@@ -390,6 +410,8 @@ t.")
       loopy--skip-used
       loopy--tagbody-exit-used
       loopy--accumulation-final-updates
+      loopy--accumulation-list-end-vars
+      loopy--accumulation-variable-info
       loopy--in-sub-level
 
       ;; -- Flag Variables --


### PR DESCRIPTION
- Fix bad instruction order in `loopy--parse-sub-loop-command`.
- Some instructions for accumulation variables are order-sensitive.
- Use `nconc` to update more variables. This is much faster than using the
  function `append`.
- Fix adding onto the end of lists of explicit variables.  As anything can add
  onto the end, we need to use `nconc` each time, not just track where we think
  the end of the list is.
- Add `loopy--get-accumulation-list-end-var` for way to use same variable to
  point to last link in list.  We need to make sure that any accumulation command
  adding to the end of the list also updates the pointer to the last link in said
  list.
- Update test `accumulation-conflicting-final-updates`.
- Fix end-tracking in `adjoin`, `nconc`, `nunion`, `union`.
- Add tests that `union`, `adjoin`, `collect`,  and `append` non-destructive.
- Update the CHANGELOG.