### PR TITLE
Add CL-lib like destructuring and related features.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ This document describes the user-facing changes to Loopy.
   un-dotted pairs.
 - Add the command `map-ref`, similar to `list-ref` and `seq-ref`.
 
+### Other Changes
+
+- The default destructuring system now takes on some of the features of Emacs
+  `cl-lib` destructuring functions.  The special arguments `&key`, `&whole`, and
+  `&rest` were added in ways that make sense for Loopy.  Because the functions
+  in `seq.el` can be extended for new types, this addition only makes
+  `loopy-seq.el` redundant for the destructuring of lists and arrays.
+  - See also the new features `loopy-dsetq`, `loopy-let*`, and `loopy-ref`.
+
 ## 0.7.2
 
 ### Bugs Fixed

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -55,6 +55,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     - [[#early-exit][Early Exit]]
   - [[#sub-loops][Sub-loops]]
 - [[#special-variables][Special Variables]]
+- [[#destructuring-macros][Destructuring Macros]]
 - [[#the-loopy-iter-macro][The ~loopy-iter~ Macro]]
 - [[#using-flags][Using Flags]]
 - [[#custom-aliases][Custom Aliases]]
@@ -521,53 +522,107 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 
   #+cindex: variable destructuring
   For convenience, =VAR= can be a sequence, either a list or a vector (as a
-  stand-in for an array), of symbols instead of a single symbol.  This tells
-  the command to “de-structure” the value of =EXPR=, similar to the functions
-  ~seq-let~, ~cl-destructuring-bind~, and ~pcase-let~.  This sequence of
-  symbols can be shorter than the destructured sequence, /but not longer/.  If
-  shorter, the unassigned elements of the list are simply ignored.  To assign
-  the final ~cdr~ of a destructured list, use dotted notation.
+  stand-in for an array), of symbols instead of a single symbol.  This tells the
+  command to “de-structure” the value of =EXPR=, similar to the functions
+  ~seq-let~, ~cl-destructuring-bind~, and ~pcase-let~.  This sequence of symbols
+  can be shorter than the destructured sequence, /but not longer/.  If shorter,
+  the unassigned elements of the list are simply ignored.
 
-  #+caption: Several examples of destructuring.
-  #+begin_src emacs-lisp
-    ;; => [(9 10 11 4) (9 10 11 8)]
-    (loopy (with (my-array [(1 2 3 4) (5 6 7 8)]))
-           (array-ref (i j k) my-array)
-           ;; NOTE: The remaining elements are ignored.
-           (do (setf i 9)
-               (setf j 10)
-               (setf k 11))
-           (finally-return my-array))
+  An element in the sequence =VAR= can be one of the following:
+  - A positional variable which will be bound to the corresponding element in
+    the sequence.  These variables can be recursive.
 
-    ;; => ([9 10 11 4] [9 10 11 8])
-    (loopy (with (my-list '([1 2 3 4 ] [5 6 7 8])))
-           (list-ref [i j k] my-list)
-           ;; NOTE: The remaining elements are ignored.
-           (do (setf i 9)
-               (setf j 10)
-               (setf k 11))
-           (finally-return my-list))
+    #+begin_src emacs-lisp
+      ;; ((1 2 3) (4 5 6))
+      (loopy (list [i (j k)] '([1 (2 3)] [4 (5 6)]))
+             (collect (list i j k)))
+    #+end_src
 
-    ;; => (1 (2 3))
-    (loopy (list (i . j) '((1 2 3)))
-           (finally-return i j))
+  - =&whole=: If =&whole= is the first element in the sequence, then the second
+    element names a variable that holds the entire value of the destructured
+    value.
 
-    ;; => ((1 22))
-    (loopy (with (my-list '((1 2 3))))
-           (list-ref (_ . j) my-list)
-           (do (setf j '(22)))
-           (finally-return my-list))
+    #+begin_src emacs-lisp
+      ;; => (((1 2 3) 1 2 3) ((4 5 6) 4 5 6))
+      (loopy (list (&whole whole i j k)  '((1 2 3) (4 5 6)))
+             (collect (list whole i j k)))
+    #+end_src
 
-    ;; => [(1 22)]
-    (loopy (with (my-array [(1 2 3)]))
-           (array-ref (_ . j) my-array)
-           (do (setf j '(22)))
-           (finally-return my-array))
-  #+end_src
+  - =&rest=: A variable named after =&rest= contains the remaining elements of
+    the destructured value.  Alternatively, one can use dotted notation in
+    lists.  These variables can be recursive.
 
-  Most commands that assign variables can use destructuring, but
-  not all kinds of destructuring make sense in all situations.
+    #+begin_src emacs-lisp
+      ;; => ((1 [2 3]) (4 [5 6]))
+      (loopy (list [i &rest j] '([1 2 3] [4 5 6]))
+             (collect (list i j)))
 
+      ;; => ((1 (2 3)) (4 (5 6)))
+      (loopy (list (i . j) '((1 2 3) (4 5 6)))
+             (collect (list i j)))
+
+      ;; Works the same as above:
+      (loopy (list (i &rest j) '((1 2 3) (4 5 6)))
+             (collect (list i j)))
+
+      ;; => ((1 2 3) (4 5 6))
+      (loopy (list (i . [j k]) '((1 . [2 3]) (4 . [5 6])))
+             (collect (list i j k)))
+
+      ;; Works the same as above:
+      (loopy (list (i &rest [j k]) '((1 . [2 3]) (4 . [5 6])))
+             (collect (list i j k)))
+    #+end_src
+
+  - =&key=: Variables named after =&key= are transformed into keys whose values
+    will be sought using ~plist-get~.  Optionally, these variables can be a list
+    of 2 elements: (1) the variable and (2) a default value if that key isn't
+    found.
+    - Currently, only lists support this destructuring.
+    - Keys are sought in values after those bound to positional variables, which
+      can be the same values to the variable named by =&rest= when both are
+      used.
+    - =&key= and =&rest= can be used in any order, but =&key= must come before
+      the dot in dotted lists.
+
+    #+begin_src emacs-lisp
+      ;; => ((1 2) (4 5))
+      (loopy (list (&key a b) '((:b 2 :c 3 :a 1)
+                                (:a 4 :b 5 :c 6)))
+             (collect (list a b)))
+
+      ;; Giving a default value:
+      ;; Note that `nil' is not the same as a missing value.
+      ;; => ((1 2 nil 25) (4 5 24 25))
+      (loopy (list (&key a b (c 24) (d 25)) '((:b 2 :c nil :a 1)
+                                              (:a 4 :b 5)))
+             (collect (list a b c d)))
+
+      ;; Keys are only sought after positional variables:
+      ;; => ((1 2 :k1 'ignored 3))
+      (loopy (array (a b c d &key k1) [(1 2 :k1 'ignored :k1 3)])
+             (collect (list a b c d k1)))
+
+      ;; If `&rest' is used, keys are sought only in that variable:
+      ;; => ((1 (:k1 3) 3))
+      (loopy (array (a &rest b &key k1) [(1 :k1 3)])
+             (collect (list a b k1)))
+
+      ;; The below two examples work the same as the above:
+
+      (loopy (array (a &key k1 &rest b) [(1 :k1 3)])
+             (collect (list a b k1)))
+
+      (loopy (array (a &key k1 . b) [(1 :k1 3)])
+             (collect (list a b k1)))
+    #+end_src
+
+
+  Most commands that assign variables can use destructuring, but not all kinds
+  of destructuring make sense in all situations.  Accumulation commands
+  ([[#accumulation-commands]]) and commands iterating through ~setf~-able places in
+  a sequence ([[#sequence-reference-iteration]]) have their own kinds of
+  destructuring.  They are explained more in their respective sections.
 
 ** Generic Evaluation
    :PROPERTIES:
@@ -1217,6 +1272,21 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     which case the fields/places of the sequence are destructured into
     "sub-fields", like the ~cdr~ of the second array element in the example
     above.
+
+    #+attr_texinfo: :tag Caution
+    #+begin_quote
+    Be aware that using ~setf~ on an array sub-sequence named by =&rest=
+    will only overwrite values, not truncate or grow the array.
+    #+end_quote
+
+    #+attr_texinfo: :tag Warning
+    #+begin_quote
+    Unfortunately, not all kinds of recursive destructuring work on references.
+    This is a limitation of how generic setters are implemented, and is not
+    limited to ~loopy~.
+
+    Currently, the variable after =&rest= in arrays cannot be recursive.
+    #+end_quote
 
     As with the =array= and =seq= commands, the =array-ref= and =seq-ref=
     commands can use the same keywords as the =nums= command
@@ -2406,9 +2476,12 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
       #+end_src
 
 * Special Variables
+  :PROPERTIES:
+  :CUSTOM_ID: special-vars
+  :END:
 
-  Beyond loop commands, there are a few special variables that one can use
-  inside of the loop.
+  Beyond loop commands, there is one special variable that can be used inside of
+  the loop.
 
   #+vindex: loopy-first-iteration
   - =loopy-first-iteration= :: Whether the current loop is in its first
@@ -2420,6 +2493,68 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     commands.
     #+end_quote
 
+
+* Destructuring Macros
+  :PROPERTIES:
+  :CUSTOM_ID: destr-macros
+  :DESCRIPTION: Destructuring outside of the loop.
+  :END:
+
+  Loopy's built-in destructuring functionality can also be used via the macros
+  ~loopy-let*~, ~loopy-setq~, and ~loopy-ref~.  These macros are /not/ affected
+  by flags which configure destructuring ([[#flags]]), as equivalent macros are
+  already provided by those libraries.
+
+  These macros can be used anywhere, not just inside calls to ~loopy~.
+
+  #+findex: loopy-let*
+  - ~loopy-let*~ :: Use destructuring in a ~let~ form, similar to ~pcase-let~
+    and ~seq-let~.
+
+    #+begin_src emacs-lisp
+      ;; => (1 2 3 4 5 28)
+      (loopy-let* ((a 1)
+                   ([b c] [2 3])
+                   ((&keys k1 k2 (k3 28)) '(:k1 4 :k2 5)))
+        (list a b c k1 k2 k3))
+    #+end_src
+
+  #+findex: loopy-setq
+  - ~loopy-setq~ :: Use destructuring in a ~setq~ form.
+
+    #+begin_src emacs-lisp
+      ;; => (1 2 3 4 5 28)
+      (let (a b c k1 k2 k3)
+        (loopy-setq a 1
+                    [b c] [2 3]
+                    (&keys k1 k2 (k3 28)) '(:k1 4 :k2 5))
+        (list a b c k1 k2 k3))
+    #+end_src
+
+  #+findex: loopy-ref
+  - ~loopy-ref~ :: Create destructured references to the fields in a sequence
+    via ~cl-symbol-macrolet~.  This is not to be confused with ~cl-letf~, which
+    temporarily binds those places to a value.
+
+    This macro exposes the destructuring used in the sequence reference
+    iteration commands ([[#sequence-reference-iteration]]).  There are some
+    limitations to this functionality in Emacs Lisp, which are described in that
+    section.
+
+    #+begin_src emacs-lisp
+      ;; => ((20 2 23) [24 25 26])
+      (let ((l1 (list 1 2 3))
+            (a1 (vector 4 5 6)))
+        (loopy-ref (((a _ b) l1)
+                    ([c &rest d] a1))
+          (setf a 20
+                b 23
+                c 24
+                d [25 26]))
+        (list l1 a1))
+    #+end_src
+
+  
 * The ~loopy-iter~ Macro
   :PROPERTIES:
   :CUSTOM_ID: loopy-iter

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -39,6 +39,7 @@ and @samp{cl-lib} (@ref{Top,,,cl,}) libraries and Emacs's regular looping and ma
 * Special Macro Arguments::      Creating the environment of the loop.
 * Loop Commands::                The main features of `loopy'.
 * Special Variables::
+* Destructuring Macros::         Destructuring outside of the loop.
 * The @code{loopy-iter} Macro::  Embedding loop commands in arbitrary code.
 * Using Flags::                  Using flags to change behavior.
 * Custom Aliases::               How to add one's own aliases.
@@ -505,7 +506,7 @@ attempting to do something like the below example might not do what you
 expect, as @samp{i} is assigned a value from the list after collecting @samp{i} into
 @samp{coll}.
 
-@float Listing,orga9e0feb
+@float Listing,org839f712
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -568,54 +569,118 @@ tries to note when that is not the case.
 
 @cindex variable destructuring
 For convenience, @samp{VAR} can be a sequence, either a list or a vector (as a
-stand-in for an array), of symbols instead of a single symbol.  This tells
-the command to “de-structure” the value of @samp{EXPR}, similar to the functions
-@code{seq-let}, @code{cl-destructuring-bind}, and @code{pcase-let}.  This sequence of
-symbols can be shorter than the destructured sequence, @emph{but not longer}.  If
-shorter, the unassigned elements of the list are simply ignored.  To assign
-the final @code{cdr} of a destructured list, use dotted notation.
+stand-in for an array), of symbols instead of a single symbol.  This tells the
+command to “de-structure” the value of @samp{EXPR}, similar to the functions
+@code{seq-let}, @code{cl-destructuring-bind}, and @code{pcase-let}.  This sequence of symbols
+can be shorter than the destructured sequence, @emph{but not longer}.  If shorter,
+the unassigned elements of the list are simply ignored.
 
-@float Listing,org516c5b6
+An element in the sequence @samp{VAR} can be one of the following:
+@itemize
+@item
+A positional variable which will be bound to the corresponding element in
+the sequence.  These variables can be recursive.
+
 @lisp
-;; => [(9 10 11 4) (9 10 11 8)]
-(loopy (with (my-array [(1 2 3 4) (5 6 7 8)]))
-       (array-ref (i j k) my-array)
-       ;; NOTE: The remaining elements are ignored.
-       (do (setf i 9)
-           (setf j 10)
-           (setf k 11))
-       (finally-return my-array))
-
-;; => ([9 10 11 4] [9 10 11 8])
-(loopy (with (my-list '([1 2 3 4 ] [5 6 7 8])))
-       (list-ref [i j k] my-list)
-       ;; NOTE: The remaining elements are ignored.
-       (do (setf i 9)
-           (setf j 10)
-           (setf k 11))
-       (finally-return my-list))
-
-;; => (1 (2 3))
-(loopy (list (i . j) '((1 2 3)))
-       (finally-return i j))
-
-;; => ((1 22))
-(loopy (with (my-list '((1 2 3))))
-       (list-ref (_ . j) my-list)
-       (do (setf j '(22)))
-       (finally-return my-list))
-
-;; => [(1 22)]
-(loopy (with (my-array [(1 2 3)]))
-       (array-ref (_ . j) my-array)
-       (do (setf j '(22)))
-       (finally-return my-array))
+;; ((1 2 3) (4 5 6))
+(loopy (list [i (j k)] '([1 (2 3)] [4 (5 6)]))
+       (collect (list i j k)))
 @end lisp
-@caption{Several examples of destructuring.}
-@end float
 
-Most commands that assign variables can use destructuring, but
-not all kinds of destructuring make sense in all situations.
+@item
+@samp{&whole}: If @samp{&whole} is the first element in the sequence, then the second
+element names a variable that holds the entire value of the destructured
+value.
+
+@lisp
+;; => (((1 2 3) 1 2 3) ((4 5 6) 4 5 6))
+(loopy (list (&whole whole i j k)  '((1 2 3) (4 5 6)))
+       (collect (list whole i j k)))
+@end lisp
+
+@item
+@samp{&rest}: A variable named after @samp{&rest} contains the remaining elements of
+the destructured value.  Alternatively, one can use dotted notation in
+lists.  These variables can be recursive.
+
+@lisp
+;; => ((1 [2 3]) (4 [5 6]))
+(loopy (list [i &rest j] '([1 2 3] [4 5 6]))
+       (collect (list i j)))
+
+;; => ((1 (2 3)) (4 (5 6)))
+(loopy (list (i . j) '((1 2 3) (4 5 6)))
+       (collect (list i j)))
+
+;; Works the same as above:
+(loopy (list (i &rest j) '((1 2 3) (4 5 6)))
+       (collect (list i j)))
+
+;; => ((1 2 3) (4 5 6))
+(loopy (list (i . [j k]) '((1 . [2 3]) (4 . [5 6])))
+       (collect (list i j k)))
+
+;; Works the same as above:
+(loopy (list (i &rest [j k]) '((1 . [2 3]) (4 . [5 6])))
+       (collect (list i j k)))
+@end lisp
+
+@item
+@samp{&key}: Variables named after @samp{&key} are transformed into keys whose values
+will be sought using @code{plist-get}.  Optionally, these variables can be a list
+of 2 elements: (1) the variable and (2) a default value if that key isn't
+found.
+@itemize
+@item
+Currently, only lists support this destructuring.
+@item
+Keys are sought in values after those bound to positional variables, which
+can be the same values to the variable named by @samp{&rest} when both are
+used.
+@item
+@samp{&key} and @samp{&rest} can be used in any order, but @samp{&key} must come before
+the dot in dotted lists.
+@end itemize
+
+@lisp
+;; => ((1 2) (4 5))
+(loopy (list (&key a b) '((:b 2 :c 3 :a 1)
+                          (:a 4 :b 5 :c 6)))
+       (collect (list a b)))
+
+;; Giving a default value:
+;; Note that `nil' is not the same as a missing value.
+;; => ((1 2 nil 25) (4 5 24 25))
+(loopy (list (&key a b (c 24) (d 25)) '((:b 2 :c nil :a 1)
+                                        (:a 4 :b 5)))
+       (collect (list a b c d)))
+
+;; Keys are only sought after positional variables:
+;; => ((1 2 :k1 'ignored 3))
+(loopy (array (a b c d &key k1) [(1 2 :k1 'ignored :k1 3)])
+       (collect (list a b c d k1)))
+
+;; If `&rest' is used, keys are sought only in that variable:
+;; => ((1 (:k1 3) 3))
+(loopy (array (a &rest b &key k1) [(1 :k1 3)])
+       (collect (list a b k1)))
+
+;; The below two examples work the same as the above:
+
+(loopy (array (a &key k1 &rest b) [(1 :k1 3)])
+       (collect (list a b k1)))
+
+(loopy (array (a &key k1 . b) [(1 :k1 3)])
+       (collect (list a b k1)))
+@end lisp
+@end itemize
+
+
+Most commands that assign variables can use destructuring, but not all kinds
+of destructuring make sense in all situations.  Accumulation commands
+(@ref{Accumulation}) and commands iterating through @code{setf}-able places in
+a sequence (@ref{Sequence Reference Iteration}) have their own kinds of
+destructuring.  They are explained more in their respective sections.
 
 @menu
 * Generic Evaluation::           Setting variables, evaluating expressions, etc.
@@ -1297,6 +1362,21 @@ Like other commands, field/reference commands can also use destructuring, in
 which case the fields/places of the sequence are destructured into
 ``sub-fields'', like the @code{cdr} of the second array element in the example
 above.
+
+@quotation Caution
+Be aware that using @code{setf} on an array sub-sequence named by @samp{&rest}
+will only overwrite values, not truncate or grow the array.
+
+@end quotation
+
+@quotation Warning
+Unfortunately, not all kinds of recursive destructuring work on references.
+This is a limitation of how generic setters are implemented, and is not
+limited to @code{loopy}.
+
+Currently, the variable after @samp{&rest} in arrays cannot be recursive.
+
+@end quotation
 
 As with the @samp{array} and @samp{seq} commands, the @samp{array-ref} and @samp{seq-ref}
 commands can use the same keywords as the @samp{nums} command
@@ -2610,8 +2690,8 @@ variables used for accumulation.
 @node Special Variables
 @chapter Special Variables
 
-Beyond loop commands, there are a few special variables that one can use
-inside of the loop.
+Beyond loop commands, there is one special variable that can be used inside of
+the loop.
 
 @vindex loopy-first-iteration
 @table @asis
@@ -2624,6 +2704,72 @@ You should not attempt to set this variable, as it is used by some loop
 commands.
 
 @end quotation
+@end table
+
+@node Destructuring Macros
+@chapter Destructuring Macros
+
+Loopy's built-in destructuring functionality can also be used via the macros
+@code{loopy-let*}, @code{loopy-setq}, and @code{loopy-ref}.  These macros are @emph{not} affected
+by flags which configure destructuring (@ref{Using Flags}), as equivalent macros are
+already provided by those libraries.
+
+These macros can be used anywhere, not just inside calls to @code{loopy}.
+
+@findex loopy-let*
+@table @asis
+@item @code{loopy-let*}
+Use destructuring in a @code{let} form, similar to @code{pcase-let}
+and @code{seq-let}.
+
+@lisp
+;; => (1 2 3 4 5 28)
+(loopy-let* ((a 1)
+             ([b c] [2 3])
+             ((&keys k1 k2 (k3 28)) '(:k1 4 :k2 5)))
+  (list a b c k1 k2 k3))
+@end lisp
+@end table
+
+@findex loopy-setq
+@table @asis
+@item @code{loopy-setq}
+Use destructuring in a @code{setq} form.
+
+@lisp
+;; => (1 2 3 4 5 28)
+(let (a b c k1 k2 k3)
+  (loopy-setq a 1
+              [b c] [2 3]
+              (&keys k1 k2 (k3 28)) '(:k1 4 :k2 5))
+  (list a b c k1 k2 k3))
+@end lisp
+@end table
+
+@findex loopy-ref
+@table @asis
+@item @code{loopy-ref}
+Create destructured references to the fields in a sequence
+via @code{cl-symbol-macrolet}.  This is not to be confused with @code{cl-letf}, which
+temporarily binds those places to a value.
+
+This macro exposes the destructuring used in the sequence reference
+iteration commands (@ref{Sequence Reference Iteration}).  There are some
+limitations to this functionality in Emacs Lisp, which are described in that
+section.
+
+@lisp
+;; => ((20 2 23) [24 25 26])
+(let ((l1 (list 1 2 3))
+      (a1 (vector 4 5 6)))
+  (loopy-ref (((a _ b) l1)
+              ([c &rest d] a1))
+    (setf a 20
+          b 23
+          c 24
+          d [25 26]))
+  (list l1 a1))
+@end lisp
 @end table
 
 @node The @code{loopy-iter} Macro

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -87,7 +87,6 @@
 (require 'subr-x)
 
 (declare-function loopy--bound-p "loopy")
-(declare-function loopy--destructure-sequence "loopy")
 (defvar loopy--in-sub-level)
 
 ;;;; Variables from flags

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "27.1") (loopy "0.8.1"))
+;; Version: 0.7.2
+;; Package-Requires: ((emacs "27.1") (loopy "0.7.2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs alists
 

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -1564,6 +1564,7 @@ you can use in the instructions:
                            ;; Make sure to adjust `args' for commands that
                            ;; might depend on positions, such as `find'.
                            (let ((args (cons into-var args)))
+                             (ignore args)
                              ,explicit)
                          ,implicit)
                     explicit)))

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "25.1") (loopy "0.8.1") (dash "2"))
+;; Version: 0.7.2
+;; Package-Requires: ((emacs "25.1") (loopy "0.7.2") (dash "2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.7.2
-;; Package-Requires: ((emacs "25.1") (loopy "0.7.1") (dash "2"))
+;; Version: 0.8.1
+;; Package-Requires: ((emacs "25.1") (loopy "0.8.1") (dash "2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 
@@ -39,6 +39,7 @@
 
 ;;; Code:
 (require 'loopy)
+(require 'loopy-misc)
 (require 'dash)
 (require 'cl-lib)
 

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: March 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.7.2
+;; Version: 0.8.1
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: March 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
+;; Version: 0.7.2
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -1,0 +1,687 @@
+;;; loopy-misc.el --- Miscellaneous functions used with Loopy. -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2020 Earl Hyatt
+
+;; Author: Earl Hyatt
+;; Created: July 2021
+;; URL: https://github.com/okamsn/loopy
+;; Version: 0.8.1
+;; Package-Requires: ((emacs "27.1") (map "3.0"))
+;; Keywords: extensions
+;; LocalWords:  Loopy's emacs
+
+;;; Disclaimer:
+;; This file is not part of GNU Emacs.
+;;
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; `loopy' is a macro that is used similarly to `cl-loop'.  It provides "loop
+;; commands" that define a loop body and it's surrounding environment, as well
+;; as exit conditions.
+;;
+;; This library provides features used by several of the libraries that form
+;; the package `loopy'.  This separation exists for better organization.
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'seq)
+(require 'subr-x)
+
+;;;; List Processing
+
+(defun loopy--every-other (list)
+  "Return a list of every other element in LIST, starting with the first.
+
+This is helpful when working with property lists."
+  (cl-loop for i in list by #'cddr collect i))
+
+;; TODO: Would this be more useful as a `pcase' macro?
+
+;; Note: This macro cannot currently be replaced by `cl-destructuring-bind' or
+;;       `map-let'.
+;;       - `map-let' provides no way to specify a default value when a key is
+;;         not in PLIST.  This macro does.
+;;       - `cl-destructuring-bind' signals an error when a key is in PLIST that
+;;         is not in BINDINGS.  This macro does not.
+(defmacro loopy--plist-bind (bindings plist &rest body)
+  "Bind values in PLIST to variables in BINDINGS, surrounding BODY.
+
+- PLIST is a property list.
+
+- BINDINGS is of the form (KEY VAR KEY VAR ...).  VAR can
+  optionally be a list of two elements: a variable name and a
+  default value, similar to what one would use for expressing
+  keyword parameters in `cl-defun' or `cl-destructuring-bind'.
+  The default value is used /only/ when KEY is not found in
+  PLIST.
+
+- BODY is the same as in `let'.
+
+This macro works the same as `cl-destructuring-bind', except for
+the case when keys exist in PLIST that are not listed in
+BINDINGS.  While `cl-destructuring-bind' would signal an error,
+this macro simply ignores them."
+  (declare (indent 2))
+  (let ((value-holder (gensym "plist-let-"))
+        (found-key (gensym "plist-prop-found-")))
+    `(let* ((,value-holder ,plist)
+            ,@(cl-loop for (key var . _) on bindings by #'cddr
+                       if (consp var)
+                       collect `(,(cl-first var)
+                                 ;; Use `plist-member' instead of `plist-get' to
+                                 ;; allow giving `nil' as an argument without
+                                 ;; using the default value.
+                                 (if-let ((,found-key (plist-member ,value-holder
+                                                                    ,key)))
+                                     (cl-second ,found-key)
+                                   ,(cl-second var)))
+                       else collect `(,var (plist-get ,value-holder ,key))))
+       ,@body)))
+
+(cl-defun loopy--substitute-using (new seq &key test)
+  "Copy SEQ, substituting elements using output of function NEW.
+
+NEW receives the element as its only argument.
+
+If given predicate function TEST, replace only elements
+satisfying TEST.  This testing could also be done in NEW."
+  ;; In testing, `cl-map' seems the fastest way to do this.
+  (cl-map (if (listp seq) 'list 'array)
+          (if test
+              (lambda (x)
+                (if (funcall test x)
+                    (funcall new x)
+                  x))
+            (lambda (x) (funcall new x)))
+          seq))
+
+(cl-defun loopy--substitute-using-if (new test seq)
+  "Copy SEQ, substituting elements satisfying TEST using output of NEW.
+
+NEW receives the element as its only argument.
+
+Unlike `loopy--substitute-using', the test is required."
+  (loopy--substitute-using new seq :test test))
+
+(cl-defun loopy--split-list-before (list element &key key (test #'eq))
+  "Split LIST on ELEMENT, so that ELEMENT begins the latter part.
+
+TEST is used to determine equality.  KEY is applied to ELEMENT
+and each item in LIST.
+
+For example, using 2 as ELEMENT would split (1 2 3)
+into (1) and (2 3)."
+  (let ((first-part nil)
+        (second-part nil))
+    (setq second-part
+          (if key
+              (cl-loop for cell on list
+                       for item = (car cell)
+                       if (funcall test
+                                   (funcall key item)
+                                   (funcall key element))
+                       return cell
+                       else do (push item first-part))
+            (cl-loop for cell on list
+                     for item = (car cell)
+                     if (funcall test item element)
+                     return cell
+                     else do (push item first-part))))
+    (list (nreverse first-part)
+          second-part)))
+
+(defun loopy--split-off-last-item (list)
+  "Split LIST, returning a list of the first items and the last item.
+
+For example, splitting (1 2 3) returns ((1 2) 3)."
+  ;; TODO: How does this compare with `last' and `butlast' for small lists?
+  (let ((reverse-list (reverse list)))
+    (list (reverse (cl-rest reverse-list))
+          (cl-first reverse-list))))
+
+
+
+
+;;;; Destructuring
+;;;;; Destructuring normal values
+;;
+;; Note that functions which are only used for commands are found in
+;; `loopy-commands.el'.  The functions found here are used generally.
+
+(defun loopy--destructure-sequence (seq value-expression)
+  "Return a list of bindings destructuring VALUE-EXPRESSION according to SEQ.
+
+Return a list of variable-value pairs (not dotted), suitable for
+substituting into a `let*' form or being combined under a `setq'
+form.
+
+If SEQ is `_', then a generated variable name will be used."
+  (cl-typecase seq
+    (symbol `((,(if (eq '_ seq) (gensym "ignored-value-") seq)
+               ,value-expression)))
+    (list (loopy--destructure-list seq value-expression))
+    (array (loopy--destructure-array seq value-expression))
+    (t (error "Type unknown: %s" seq))))
+
+(defun loopy--destructure-array (var value-expression)
+  "Return a list of bindings destructuring VALUE-EXPRESSION according to VAR.
+
+- If `&rest', bind the remaining values in the array.
+- If `&whole', name a variable holding the whole value."
+  (let ((bindings)
+        (holding-var)
+        (remaining-var))
+    (if (eq '&whole (aref var 0))
+        (setq holding-var (aref var 1)
+              remaining-var (seq-drop var 2))
+      (setq holding-var (gensym "cl-array-")
+            remaining-var var))
+
+    (push `(,holding-var ,value-expression)
+          bindings)
+
+    (cl-loop named loop
+             with array-length = (length remaining-var)
+             for v across remaining-var
+             for idx from 0
+             do (cond
+                 ((eq v '_)) ; Do nothing if variable is `_'.
+                 ((eq v '&rest)
+                  (let* ((next-idx (1+ idx))
+                         (next-var (aref remaining-var next-idx)))
+                    ;; Check that the var after `&rest' is the last:
+                    (when (> (1- array-length) next-idx)
+                      (error "More than one variable after `&rest': %s"
+                             var))
+
+                    (if (sequencep next-var)
+                        (dolist (binding (loopy--destructure-sequence
+                                          next-var `(seq-subseq ,holding-var
+                                                                ,idx)))
+                          (push binding bindings))
+                      (push `(,next-var (seq-subseq ,holding-var ,idx))
+                            bindings))
+                    ;; Exit the loop.
+                    (cl-return-from loop)))
+                 (t (if (sequencep v)
+                        (dolist (binding (loopy--destructure-sequence
+                                          v `(aref ,holding-var ,idx)))
+                          (push binding bindings))
+                      (push `(,v (aref ,holding-var ,idx))
+                            bindings)))))
+    (nreverse bindings)))
+
+(cl-defun loopy--destructure-list (var value-expression)
+  "Destructure VALUE-EXPRESSION according to VAR.
+
+- If the first element of VAR is `&whole', then the next element
+  names a variable containing the entire value.
+- Positional variable names can be next.
+- A variable named after `&rest' or after the dot in a dotted list
+  sets that variable to the remainder of the list.  If no positional
+  variables are given, then this is the same as `&whole'.
+- Variables named after `&key' are values found using plist functions.
+  These can optionally be a list of 2 element: (1) a variable name
+  and (2) a default value if the corresponding key is not present.
+  Keys are only sought in the remainder of the list, be that after
+  positional variable names or in a variable named `&rest'.
+
+Only the positional variables and the remainder can be recursive."
+  (let ((bindings nil)                  ; The result of this function.
+        (whole-var nil)                 ; Variable after `&whole'.
+        (rest-var nil)                  ; Variable after `&rest'.
+        (rest-var-was-sequence nil)     ; Whether that var was a sequence.
+        (key-target-var (gensym "key-target-")) ; Holder for if we only use keys.
+        (key-vars))                     ; Variables after `&key' or `&keys'.
+
+    (when (eq (cl-first var) '&whole)
+      (cond
+       ;; Make sure there is a variable named.
+       ((null (cdr var))
+        (error "Bad destructuring: %s" var))
+       ;; If it's the only variable named, just bind it and return.
+       ((not (cddr var))
+        (warn "`&whole' used when only one variable listed: %s" var)
+        (cl-return-from loopy--destructure-list
+          `((,(cl-second var) ,value-expression))))
+       (t
+        (let ((possible-whole-var (cl-second var)))
+          (setq whole-var (if (eq possible-whole-var '_)
+                              (progn
+                                (warn "`&whole' won't be ignored: %s" var)
+                                (gensym "list-whole-"))
+                            possible-whole-var)
+                ;; Now just operate on remaining variables.
+                var (cddr var))
+          (push `(,whole-var ,value-expression) bindings)))))
+
+    ;; Find any (_ &rest `rest') or (_ . `rest') variable.
+    (let ((possible-rest-var))
+      (if (proper-list-p var)
+          (seq-let (before after) (loopy--split-list-before var '&rest)
+
+            (unless before (warn "`&rest' being treated same as `&whole': %s" var))
+
+            (when after
+              ;; This is the best place to check that argument only uses
+              ;; keys after the `rest-var'.
+              (if-let* ((vars-after-rest-var (cddr after)))
+                  (progn
+                    (unless (memq (cl-first vars-after-rest-var) '(&key &keys))
+                      (error "Bad arguments after `&rest' var: %s"
+                             vars-after-rest-var))
+                    ;; Now just operate on remaining variables.
+                    (setq var (append before vars-after-rest-var)))
+                (setq var before))
+
+              (setq possible-rest-var (cl-second after))))
+
+        ;; If VAR is not a proper list, then the last cons cell is dotted.
+        (setq possible-rest-var (cdr (last var))
+              ;; Now just operate on remaining variables.
+              ;; TODO: We use this `car-safe' phrasing in several places.
+              ;;       Is there a better way?
+              var (let ((var-copy var)
+                        (result))
+                    ;; For a dotted pair, the final `cdr' is not `car-safe',
+                    ;; since it is not a list.  We do not perform that final `cdr'.
+                    (while (car-safe var-copy)
+                      (push (pop var-copy)
+                            result))
+                    (nreverse result))))
+
+      ;; Finally, bind the &rest var, if any.
+      (unless (eq possible-rest-var '_)
+        ;; NOTE: For sequence `&rest' vars, we need to destructure
+        ;;       /after/ the normal variables have been `pop'-ed off
+        ;;       of the value.
+        (if (sequencep possible-rest-var)
+            (setq rest-var-was-sequence possible-rest-var
+                  rest-var (gensym "list-rest-"))
+          (setq rest-var possible-rest-var))
+        (push `(,rest-var ,(or whole-var value-expression))
+              bindings)))
+
+    ;; Find the key vars, if any.  The key vars must be drawn from
+    ;; the remaining part after the normal variables of bound.
+    (seq-let (before after)
+        (loopy--split-list-before var '&key)
+      ;; We might as well be forgiving of this mistake.
+      (unless after
+        (seq-let (bef aft)
+            (loopy--split-list-before var '&keys)
+          (setq before bef after aft)))
+      (when after
+        (setq key-vars (cdr after)
+              var before)))
+
+    ;; Handle the normal variables.  Generally, we want to `pop' the normal
+    ;; values off of some container variable.  This could be the variable used
+    ;; after `&rest', the variable in which keys after `&key' will be sought,
+    ;; a copy of the variable after `&whole', or just the last variable given.
+    ;;
+    ;; TODO: This code is very simple, but could probably be condensed.
+    (when var
+      (cond
+       (rest-var
+        (dolist (i var)
+          (cond
+           ((sequencep i)
+            (dolist (binding (loopy--destructure-sequence
+                              i `(pop ,rest-var)))
+              (push binding bindings)))
+           ((eq i '_)
+            (push `(,rest-var (cdr ,rest-var))
+                  bindings))
+           (t
+            (push `(,i (pop ,rest-var))
+                  bindings))))
+
+        ;; NOTE: For sequence `&rest' vars, we need to destructure
+        ;;       /after/ the normal variables have been `pop'-ed off
+        ;;       of the value.
+        (when rest-var-was-sequence
+          (dolist (bind (loopy--destructure-sequence
+                         rest-var-was-sequence rest-var))
+            (push bind bindings))))
+       (key-vars
+        (if whole-var
+            (push `(,key-target-var ,whole-var)
+                  bindings)
+          (push `(,key-target-var ,value-expression)
+                bindings))
+        (dolist (i var)
+          ;; `pop' off of key-target-var to reduce the search for keys.
+          (cond
+           ((sequencep i)
+            (dolist (binding (loopy--destructure-sequence
+                              i `(pop ,key-target-var)))
+              (push binding bindings)))
+           ((eq i '_)
+            (push `(,key-target-var (cdr ,key-target-var))
+                  bindings))
+           (t
+            (push `(,i (pop ,key-target-var))
+                  bindings)))))
+       (whole-var
+        ;; We want to create a copy of the `whole-var', then pop values
+        ;; off of that copy.
+        (let ((whole-copy (gensym "whole-copy-")))
+          (seq-let (other-vars last-var)
+              (loopy--split-off-last-item var)
+            (if (sequencep last-var)
+                (progn
+                  (push `(,whole-copy ,whole-var) bindings)
+
+                  (dolist (i other-vars)
+                    (cond
+                     ;; Handle sequences.
+                     ((sequencep i)
+                      (dolist (binding (loopy--destructure-sequence
+                                        i `(pop ,whole-copy)))
+                        (push binding bindings)))
+                     ;; Handle ignored variables.
+                     ((eq i '_)
+                      (push `(,whole-copy (cdr ,whole-copy))
+                            bindings))
+                     ;; Handle normal variables.
+                     (t
+                      (push `(,i (pop ,whole-copy))
+                            bindings))))
+
+                  ;; Now destructure the sequence on the remaining value
+                  ;; after all of the `pop'-ing.
+                  (dolist (bind (loopy--destructure-sequence
+                                 last-var `(car ,whole-copy)))
+                    (push bind bindings)))
+
+              ;; Otherwise, we just use the last variable as the copy.
+              ;;
+              ;; TODO: Instead of generating a variable, we should just move
+              ;;       up further in the list and try again.
+              (let ((last-var-ignored (eq last-var '_)))
+                (when last-var-ignored
+                  (setq last-var (gensym "last-var-in-list")))
+                (push `(,last-var ,whole-var) bindings)
+                (dolist (i other-vars)
+                  (cond
+                   ((sequencep i)
+                    (dolist (binding (loopy--destructure-sequence
+                                      i `(pop ,last-var)))
+                      (push binding bindings)))
+                   ((eq i '_)
+                    (push `(,last-var (cdr ,last-var))
+                          bindings))
+                   (t
+                    (push `(,i (pop ,last-var))
+                          bindings))))
+
+                (unless last-var-ignored
+                  (push `(,last-var (car ,last-var))
+                        bindings)))))))
+
+       (t
+        (seq-let (other-vars last-var)
+            (loopy--split-off-last-item var)
+          (if (sequencep last-var)
+              (let ((list-copy (gensym "list-copy")))
+                (push `(,list-copy ,value-expression)
+                      bindings)
+
+                (dolist (i other-vars)
+                  (if (sequencep i)
+                      (dolist (bind (loopy--destructure-sequence
+                                     i `(pop ,list-copy)))
+                        (push bind bindings))
+                    (push `(,i (pop ,list-copy)) bindings)))
+
+                (dolist (bind (loopy--destructure-sequence
+                               last-var `(car ,list-copy)))
+                  (push bind bindings)))
+            (let ((last-var-ignored (eq last-var '_)))
+              (when last-var-ignored
+                (setq last-var (gensym "last-var-in-list-")))
+              (push `(,last-var ,value-expression)
+                    bindings)
+              (dolist (i other-vars)
+                (cond
+                 ((sequencep i)
+                  (dolist (bind (loopy--destructure-sequence
+                                 i `(pop ,last-var)))
+                    (push bind bindings)))
+                 ((eq i '_)
+                  (push `(,last-var (cdr ,last-var))
+                        bindings))
+                 (t
+                  (push `(,i (pop ,last-var))
+                        bindings))))
+              ;; Extract final value from the list of a single value.
+              (unless last-var-ignored
+                (push `(,last-var (car ,last-var))
+                      bindings))))))))
+
+    ;; Now process the keys.
+    (when key-vars
+      (unless bindings
+        (push `(,key-target-var ,value-expression)
+              bindings))
+      (let ((target-var (or rest-var
+                            ;; If we used positional variables.
+                            (if var key-target-var)
+                            whole-var
+                            key-target-var)))
+        (dolist (i key-vars)
+          (push (if (consp i)
+                    `(,(car i)
+                      ,(let ((key (intern (format ":%s" (car i)))))
+                         `(if-let ((key-found (plist-member ,target-var ,key)))
+                              (cl-second key-found)
+                            ,(cl-second i))))
+                  (let ((key (intern (format ":%s" i))))
+                    `(,i (plist-get ,target-var ,key))))
+                bindings))))
+
+    ;; Fix the order of the bindings and return.
+    (nreverse bindings)))
+
+;;;;; Destructuring Generalized Variables
+(defun loopy--destructure-generalized-sequence (var value-expression)
+  "Destructure VALUE-EXPRESSION according to VAR as `setf'-able places.
+
+VALUE-EXPRESSION should itself be a `setf'-able place.
+
+Returns a list of bindings suitable for `cl-symbol-macrolet'."
+  (cl-typecase var
+    (symbol (unless (eq var '_)
+              `((,var ,value-expression))))
+    (list   (loopy--destructure-generalized-list var value-expression))
+    (array  (loopy--destructure-generalized-array var value-expression))
+    (t      (error "Type not recognized: %s" var))))
+
+(defun loopy--destructure-generalized-array (var value-expression)
+  "Destructure VALUE-EXPRESSION according to VAR as `setf'-able places.
+
+VALUE-EXPRESSION should itself be a `setf'-able place.
+
+Returns a list of bindings suitable for `cl-symbol-macrolet'.
+
+- `&rest' references a subsequence place.
+- `&whole' references the entire place."
+  (let ((bindings)
+        (remaining-var))
+    (if (eq '&whole (aref var 0))
+        (progn
+          (push `(,(aref var 1) ,value-expression)
+                bindings)
+          (setq remaining-var (seq-drop var 2)))
+      (setq remaining-var var))
+
+    (cl-loop named loop
+             with array-length = (length remaining-var)
+             for v across remaining-var
+             for idx from 0
+             do (cond
+                 ((eq v '_)) ; Do nothing if variable is `_'.
+                 ((eq v '&rest)
+                  (let* ((next-idx (1+ idx))
+                         (next-var (aref remaining-var next-idx)))
+                    ;; Check that the var after `&rest' is the last:
+                    (when (> (1- array-length) next-idx)
+                      (error "More than one variable after `&rest': %s"
+                             var))
+
+                    (if (sequencep next-var)
+                        (dolist (binding (loopy--destructure-generalized-sequence
+                                          ;; Note: `seq-subseq' doesn't have a
+                                          ;; setter, but `cl-subseq' does.
+                                          next-var `(cl-subseq ,value-expression
+                                                               ,idx)))
+                          (push binding bindings))
+                      (push `(,next-var (cl-subseq ,value-expression ,idx))
+                            bindings))
+                    ;; Exit the loop.
+                    (cl-return-from loop)))
+                 (t (if (sequencep v)
+                        (dolist (binding (loopy--destructure-generalized-sequence
+                                          v `(aref ,value-expression ,idx)))
+                          (push binding bindings))
+                      (push `(,v (aref ,value-expression ,idx))
+                            bindings)))))
+    (nreverse bindings)))
+
+(cl-defun loopy--destructure-generalized-list (var value-expression)
+  "Destructure VALUE-EXPRESSION according to VAR as `setf'-able places.
+
+VALUE-EXPRESSION should itself be a `setf'-able place.
+
+returns a list of bindings suitable for `cl-symbol-macrolet'.
+
+- `&rest' references a subsequence place.
+- `&whole' references the entire place.
+
+See `loopy--destructure-list' for normal values."
+  (let ((bindings nil))                  ; The result of this function.
+
+    (when (eq (cl-first var) '&whole)
+      (cond
+       ;; Make sure there is a variable named.
+       ((null (cdr var))
+        (error "Bad destructuring: %s" var))
+       ;; If it's the only variable named, just bind it and return.
+       ((null (cddr var))
+        (warn "`&whole' used when only one variable listed: %s"
+              var)
+        (cl-return-from loopy--destructure-generalized-list
+          `((,(cl-second var) ,value-expression))))
+       (t
+        (let ((possible-whole-var (cl-second var)))
+          (if (eq possible-whole-var '_)
+              (warn "`&whole' variable being ignored: %s" var)
+            ;; Now just operate on remaining variables.
+            (push `(,possible-whole-var ,value-expression)
+                  bindings)))
+        (setq var (cddr var)))))
+
+    ;; Now handle the remaining variables.  Since we're not storing a value,
+    ;; we don't need to do any `pop'-ing like in `loopy--destructure-list'.
+    ;; However, we still need to keep track of where to look for keys.
+    ;;
+    ;; Since it's possible for `var' to be a dotted list, we only know
+    ;; where to look after processing the entire list `var'.
+    (let ((var-is-dotted (not (proper-list-p var)))
+          (rest-var-value nil)
+          (last-positional-var-index)
+          (positional-vars-used)
+          (key-vars))
+
+      (let ((looking-at-key-vars nil)
+            (index 0)
+            (v nil))
+        (while (car-safe var)
+          (setq v (car var))
+          (cond
+           ((eq v '_)
+            (setq var (cdr var))
+            (cl-incf index))                  ; Do nothing in this case.
+
+           ((eq v '&rest)
+            (setq looking-at-key-vars nil)
+            (when var-is-dotted
+              (error "Can't use `&rest' in dotted list: %s" var))
+            (let ((rest-var (cl-second var)))
+              (setq rest-var-value `(nthcdr ,index ,value-expression))
+              (if (sequencep rest-var)
+                  (dolist (bind (loopy--destructure-generalized-sequence
+                                 rest-var rest-var-value))
+                    (push bind bindings))
+                (push `(,rest-var ,rest-var-value)
+                      bindings)))
+            (setq var (cddr var))
+            (cl-incf index 2))
+
+           ;; For keys, we don't want to increase the index, just skip over
+           ;; them.  Key variables stop once `&rest' or the last cdr of a
+           ;; dotted list is reached (at which point the loop exits).
+           ((memq v '(&key &keys))
+            (setq looking-at-key-vars t
+                  var (cl-rest var)))
+
+           (looking-at-key-vars
+            (push v key-vars)
+            (setq var (cl-rest var)))
+
+           (t
+            (if (sequencep v)
+                (dolist (bind (loopy--destructure-generalized-sequence
+                               v `(nth ,index ,value-expression)))
+                  (push bind bindings))
+              (push `(,v (nth ,index ,value-expression)) bindings))
+            (setq var (cl-rest var)
+                  last-positional-var-index index
+                  positional-vars-used t)
+            (cl-incf index))))
+
+        ;; If it was a dotted list, then `var' is now an atom.
+        (when var
+          ;; The first `cdr' is 1, not 0, so we must add 1 here to get the
+          ;; remainder of the list after the last positional variable.
+          (let ((cdr-value `(nthcdr ,(1+ last-positional-var-index)
+                                    ,value-expression)))
+            (setq rest-var-value cdr-value)
+            (push `(,var ,cdr-value) bindings))))
+
+      ;; Decide where to look for keys, if any.
+      (when key-vars
+        (let ((key-target-value (or rest-var-value
+                                    (and positional-vars-used
+                                         ;; The first `cdr' is 1, not 0, so we
+                                         ;; must add 1 here to get the remainder
+                                         ;; of the list after the last
+                                         ;; positional variable.
+                                         `(nthcdr ,(1+ last-positional-var-index)
+                                                  ,value-expression))
+                                    value-expression)))
+          (dolist (k key-vars)
+            (push `(,k (plist-get ,key-target-value
+                                  ,(intern (format ":%s" k))))
+                  bindings)))))
+
+    ;; Fix the order of the bindings and return.
+    (nreverse bindings)))
+
+
+(provide 'loopy-misc)
+;;; loopy-misc.el ends here

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -198,7 +198,7 @@ form.
 
 If SEQ is `_', then a generated variable name will be used."
   (cl-typecase seq
-    (symbol `((,(if (eq '_ seq) (gensym "ignored-value-") seq)
+    (symbol `((,(if (loopy--var-ignored-p seq) (gensym "ignored-value-") seq)
                ,value-expression)))
     (list (loopy--destructure-list seq value-expression))
     (array (loopy--destructure-array seq value-expression))
@@ -226,7 +226,7 @@ If SEQ is `_', then a generated variable name will be used."
              for v across remaining-var
              for idx from 0
              do (cond
-                 ((eq v '_)) ; Do nothing if variable is `_'.
+                 ((loopy--var-ignored-p v)) ; Do nothing if variable is `_'.
                  ((eq v '&rest)
                   (let* ((next-idx (1+ idx))
                          (next-var (aref remaining-var next-idx)))
@@ -288,7 +288,7 @@ Only the positional variables and the remainder can be recursive."
           `((,(cl-second var) ,value-expression))))
        (t
         (let ((possible-whole-var (cl-second var)))
-          (setq whole-var (if (eq possible-whole-var '_)
+          (setq whole-var (if (loopy--var-ignored-p possible-whole-var)
                               (progn
                                 (warn "`&whole' won't be ignored: %s" var)
                                 (gensym "list-whole-"))
@@ -482,7 +482,7 @@ VALUE-EXPRESSION should itself be a `setf'-able place.
 
 Returns a list of bindings suitable for `cl-symbol-macrolet'."
   (cl-typecase var
-    (symbol (unless (eq var '_)
+    (symbol (unless (loopy--var-ignored-p var)
               `((,var ,value-expression))))
     (list   (loopy--destructure-generalized-list var value-expression))
     (array  (loopy--destructure-generalized-array var value-expression))
@@ -511,7 +511,7 @@ Returns a list of bindings suitable for `cl-symbol-macrolet'.
              for v across remaining-var
              for idx from 0
              do (cond
-                 ((eq v '_)) ; Do nothing if variable is `_'.
+                 ((loopy--var-ignored-p v)) ; Do nothing if variable is `_'.
                  ((eq v '&rest)
                   (let* ((next-idx (1+ idx))
                          (next-var (aref remaining-var next-idx)))
@@ -565,7 +565,7 @@ See `loopy--destructure-list' for normal values."
           `((,(cl-second var) ,value-expression))))
        (t
         (let ((possible-whole-var (cl-second var)))
-          (if (eq possible-whole-var '_)
+          (if (loopy--var-ignored-p possible-whole-var)
               (warn "`&whole' variable being ignored: %s" var)
             ;; Now just operate on remaining variables.
             (push `(,possible-whole-var ,value-expression)
@@ -590,7 +590,7 @@ See `loopy--destructure-list' for normal values."
         (while (car-safe var)
           (setq v (car var))
           (cond
-           ((eq v '_)
+           ((loopy--var-ignored-p v)
             (setq var (cdr var))
             (cl-incf index))                  ; Do nothing in this case.
 

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -417,7 +417,7 @@ Only the positional variables and the remainder can be recursive."
                    (when (loopy--var-ignored-p last-var)
                      (let ((reverse-good-var
                             (seq-drop-while #'loopy--var-ignored-p
-                                              (reverse other-vars))))
+                                            (reverse other-vars))))
                        (setq last-var (cl-first reverse-good-var)
                              other-vars (reverse (cl-rest reverse-good-var)))))
 
@@ -479,17 +479,22 @@ Only the positional variables and the remainder can be recursive."
                             (if positional-vars key-target-var)
                             whole-var
                             key-target-var)))
-        (pcase-dolist ((or `(,key-var ,default)
-                           key-var)
-                       key-vars)
-          (let ((key (intern (format ":%s" key-var))))
-            (push `(,key-var
-                    ,(if default
-                         `(if-let ((key-found (plist-member ,target-var ,key)))
-                              (cl-second key-found)
-                            ,default)
-                       `(plist-get ,target-var ,key)))
-                  bindings)))))
+        ;; TODO: In Emacs 28, `pcase' was changed so that all named variables
+        ;; are at least bound to nil.  Before that version, we should make sure
+        ;; that `default' is bound.
+        (let ((default nil))
+          (ignore default)
+          (pcase-dolist ((or `(,key-var ,default)
+                             key-var)
+                         key-vars)
+            (let ((key (intern (format ":%s" key-var))))
+              (push `(,key-var
+                      ,(if default
+                           `(if-let ((key-found (plist-member ,target-var ,key)))
+                                (cl-second key-found)
+                              ,default)
+                         `(plist-get ,target-var ,key)))
+                    bindings))))))
 
     ;; Fix the order of the bindings and return.
     (nreverse bindings)))

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -37,6 +37,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'pcase)
 (require 'seq)
 (require 'subr-x)
 
@@ -478,16 +479,17 @@ Only the positional variables and the remainder can be recursive."
                             (if positional-vars key-target-var)
                             whole-var
                             key-target-var)))
-        (dolist (i key-vars)
-          (push (if (consp i)
-                    `(,(car i)
-                      ,(let ((key (intern (format ":%s" (car i)))))
+        (pcase-dolist ((or `(,key-var ,default)
+                           key-var)
+                       key-vars)
+          (let ((key (intern (format ":%s" key-var))))
+            (push `(,key-var
+                    ,(if default
                          `(if-let ((key-found (plist-member ,target-var ,key)))
                               (cl-second key-found)
-                            ,(cl-second i))))
-                  (let ((key (intern (format ":%s" i))))
-                    `(,i (plist-get ,target-var ,key))))
-                bindings))))
+                            ,default)
+                       `(plist-get ,target-var ,key)))
+                  bindings)))))
 
     ;; Fix the order of the bindings and return.
     (nreverse bindings)))

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -330,18 +330,16 @@ Only the positional variables and the remainder can be recursive."
               (setq possible-rest-var (cl-second after))))
 
         ;; If VAR is not a proper list, then the last cons cell is dotted.
-        (setq possible-rest-var (cdr (last var))
-              ;; Now just operate on remaining variables.
-              ;; TODO: We use this `car-safe' phrasing in several places.
-              ;;       Is there a better way?
-              var (let ((var-copy var)
-                        (result))
-                    ;; For a dotted pair, the final `cdr' is not `car-safe',
-                    ;; since it is not a list.  We do not perform that final `cdr'.
-                    (while (car-safe var-copy)
-                      (push (pop var-copy)
-                            result))
-                    (nreverse result))))
+        ;; TODO: We use this `car-safe' phrasing in several places.
+        ;;       Is there a better way?
+        (let ((var-copy var)
+              (other-vars))
+          (while (car-safe var-copy)
+            (push (pop var-copy) other-vars))
+          ;; Now just operate on remaining variables.
+          (setq var (reverse other-vars)
+                ;; `var-copy' is now an atom.
+                possible-rest-var var-copy)))
 
       ;; Finally, bind the &rest var, if any.
       (when (and possible-rest-var

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: July 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
+;; Version: 0.7.2
 ;; Package-Requires: ((emacs "27.1") (map "3.0"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs

--- a/loopy-pcase.el
+++ b/loopy-pcase.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.7.2
-;; Package-Requires: ((emacs "25.1") (loopy "0.7.2"))
+;; Version: 0.8.1
+;; Package-Requires: ((emacs "25.1") (loopy "0.8.1"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 
@@ -39,6 +39,7 @@
 
 ;;; Code:
 (require 'loopy)
+(require 'loopy-misc)
 (require 'macroexp)
 (require 'pcase)
 (require 'cl-lib)

--- a/loopy-pcase.el
+++ b/loopy-pcase.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "25.1") (loopy "0.8.1"))
+;; Version: 0.7.2
+;; Package-Requires: ((emacs "25.1") (loopy "0.7.2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy-seq.el
+++ b/loopy-seq.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "25.1") (loopy "0.8.1"))
+;; Version: 0.7.2
+;; Package-Requires: ((emacs "25.1") (loopy "0.7.2"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy-seq.el
+++ b/loopy-seq.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.7.2
-;; Package-Requires: ((emacs "25.1") (loopy "0.7.2"))
+;; Version: 0.8.1
+;; Package-Requires: ((emacs "25.1") (loopy "0.8.1"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 
@@ -45,6 +45,7 @@
 ;; directly passing the variable list to `pcase-let'.
 
 (require 'loopy)
+(require 'loopy-misc)
 (require 'seq)
 (require 'pcase)
 (require 'loopy-pcase)

--- a/loopy.el
+++ b/loopy.el
@@ -5,8 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "27.1") (map "3.0"))
+;; Version: 0.7.2 ;; Package-Requires: ((emacs "27.1") (map "3.0"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy.el
+++ b/loopy.el
@@ -476,8 +476,6 @@ this means that an explicit \"nil\" is always required."
 
 
 ;;;###autoload
-(defalias 'loopy-dsetq #'loopy-setq) ; Named for Iterate's `dsetq'.
-;;;###autoload
 (defmacro loopy-setq (&rest args)
   "Use Loopy destructuring in a `setq' form.
 
@@ -491,6 +489,8 @@ instead of this macro.
   `(setq ,@(apply #'append
                   (cl-loop for (var val . _) on args by #'cddr
                            append (loopy--destructure-sequence var val)))))
+;;;###autoload
+(defalias 'loopy-dsetq 'loopy-setq) ; Named for Iterate's `dsetq'.
 
 ;;;###autoload
 (defmacro loopy-let* (bindings &rest body)

--- a/tests/dash-tests.el
+++ b/tests/dash-tests.el
@@ -11,16 +11,58 @@
 (require 'loopy "./loopy.el")
 (require 'loopy-dash "./loopy-dash.el")
 
-(load-file "tests/tests.el")
-
-(setq loopy-default-flags '(dash))
-
 (ert-deftest dash-flag-default ()
   (should (equal '(5 6)
                  (let ((loopy-default-flags '(dash)))
                    (eval (quote (loopy (list (&plist :a a  :b b)
                                              '((:a 3  :b 4) (:a 5 :b 6)))
                                        (finally-return a b))))))))
+
+(ert-deftest dash-flag-list-destructuring ()
+  (should (equal '(1 2)
+                 (eval (quote (loopy (flag dash)
+                                     (list (i) '((1) (2)))
+                                     (collect i))))))
+
+  (should (equal '(((1) 1) ((2) 2))
+                 (eval (quote (loopy (flag dash)
+                                     (list (whole &as i) '((1) (2)))
+                                     (collect (list whole i)))))))
+
+  (should (equal '((1 2) (3 4))
+                 (eval (quote (loopy (flag dash)
+                                     (list (i j) '((1 2) (3 4)))
+                                     (collect (list i j)))))))
+
+  (should (equal '((1 2) (3 4))
+                 (eval (quote (loopy (flag dash)
+                                     (list (i . j) '((1 . 2) (3 . 4)))
+                                     (collect (list i j)))))))
+
+  (should (equal '((1 2) (4 3))
+                 (eval (quote (loopy (flag dash)
+                                     (list (&plist :k1 i :k2 j) '((:k1 1 :k2 2)
+                                                                  (:k2 3 :k1 4)))
+                                     (collect (list i j)))))))
+
+  (should (equal '((1 2) (4 3))
+                 (eval (quote (loopy (flag dash)
+                                     (array (&alist :k1 i :k2 j) [((:k1 . 1)
+                                                                   (:k2 . 2))
+                                                                  ((:k2 . 3)
+                                                                   (:k1 . 4))])
+                                     (collect (list i j))))))))
+
+(ert-deftest dash-flag-array-destructuring ()
+  (should (equal '((1 2 3))
+                 (eval (quote (loopy (flag dash)
+                                     (list [i j k] '([1 2 3]))
+                                     (collect (list i j k)))))))
+
+  (should (equal '((1 [2 3]))
+                 (eval (quote (loopy (flag dash)
+                                     (list [i &rest j] '([1 2 3]))
+                                     (collect (list i j))))))))
 
 (ert-deftest dash-flag-default-disable ()
   :expected-result :failed

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -1020,21 +1020,19 @@ implicit variable without knowing it's name, even for named loops."
                                           (finally-return i j k))))))))
 
 (ert-deftest list-recursive-destructuring ()
-  (should
-   (and
-    (equal '(5 5 6)
-           (eval (quote (loopy (list (a (b c)) '((1 (1 2)) (5 (5 6))))
-                               (finally-return (list a b c))))))
-    (equal '(5 5 6)
-           ;; This is more of an evaluation-time test.
-           (eval (quote (loopy (list (a . (b c)) '((1 . (1 2)) (5 . (5 6))))
-                               (finally-return (list a b c))))))
-    (equal '(4 5 6)
-           (loopy (list (a . [b c]) '((1 . [2 3]) (4 . [5 6])))
-                  (finally-return a b c)))
-    (equal '(5 5 6)
-           (eval (quote (loopy (list (a (b (c))) '((1 (1 (2))) (5 (5 (6)))))
-                               (finally-return (list a b c)))))))))
+  (should (equal '(4 5 6)
+                 (eval (quote (loopy (list (a (b c)) '((1 (2 3)) (4 (5 6))))
+                                     (finally-return (list a b c)))))))
+  (should (equal '(5 5 6)
+                 ;; This is more of an evaluation-time test.
+                 (eval (quote (loopy (list (a . (b c)) '((1 . (1 2)) (5 . (5 6))))
+                                     (finally-return (list a b c)))))))
+  (should (equal '(4 5 6)
+                 (loopy (list (a . [b c]) '((1 . [2 3]) (4 . [5 6])))
+                        (finally-return a b c))))
+  (should (equal '(5 5 6)
+                 (eval (quote (loopy (list (a (b (c))) '((1 (1 (2))) (5 (5 (6)))))
+                                     (finally-return (list a b c))))))))
 
 (ert-deftest list-multi-list ()
   (should (equal '((1 4) (1 5) (1 6) (2 4) (2 5) (2 6) (3 4) (3 5) (3 6))


### PR DESCRIPTION
- Improve the default destructuring:
  - `&whole` captures the whole value.
  - `&rest` captures the remaining value, like a dotted list.
  - `&key` works as in `cl-defun`.
- Add macros `loopy-let*`, `loopy-setq`, and `loopy-ref`, which make use of this
  new style.
- Move these lower level destructuring features to `loopy-misc.el`, along with
  some of the other more generic private functions.
- Update CHANGELOG.md.
- Add more tests.
- Update Org and Texinfo docs.
- Bump version number.

These changes shouldn't break anything, only add features.

This closes #81 and adds some things from #48 (`dsetq`, etc.).