### PR TITLE
Add an `at` command, and related changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,29 @@ This document describes the user-facing changes to Loopy.
   commands while the loop is running.  This allows the loop to be much faster
   when using named variables (required for destructuring) and simplifies the
   code.  See [#83].
+- Duplicating special macro arguments (such as using `flags` twice) now signals
+  an error.  See [#87].
+- Sub-loops using the `sub-loop` command are now full `loopy` loops.
+  - They can now take special macro arguments.
+  - Their accumulation no longer affect the surrounding loop.  You must now use
+    the `at` command.  See [#70], [#87].
 
+### Other Changes
+
+- An `at` command was added, which better controls interacting with surrounding
+  loops.  This is similar to the `in` clause from Common Lisp's Iterate package.
+  See [#70], [#87].
+- The `leave-from` command has been re-added, now that code generation is more
+  robust.  See [#87].
+- A `skip-from` command was added.
+- Add feature `loopy-lambda`.  This is like `pcase-lambda`, but uses `loopy`
+  destructuring.  See [#87].
+- List `seq.el` in the package requirements.  See [#87].
+
+
+[#70]: https://github.com/okamsn/loopy/issues/70
 [#83]: https://github.com/okamsn/loopy/issues/83
+[#87]: https://github.com/okamsn/loopy/pull/87
 
 ## 0.8.1
 

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -28,9 +28,10 @@ Features might not work in other formats (e.g., Info links in HTML).
 ~cl-loop~ ([[info:cl#Loop Facility]]) but uses symbolic expressions rather than
 keywords.
 
-For most use cases, ~loopy~ should a nice substitute for ~cl-loop~ and
-complementary to the features provided by the =seq= ([[info:elisp#Sequence Functions]])
-and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping features.
+For most use cases, ~loopy~ should be a nice substitute for ~cl-loop~ and
+complementary to the features provided by the =seq= ([[info:elisp#Sequence
+Functions]]) and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and
+mapping features.
 
 -----
 
@@ -53,7 +54,7 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     - [[#conditionals][Conditionals]]
     - [[#skipping-cycles][Skipping Cycles]]
     - [[#early-exit][Early Exit]]
-  - [[#sub-loops][Sub-loops]]
+  - [[#sub-loops][Sub-Loops]]
 - [[#special-variables][Special Variables]]
 - [[#destructuring-macros][Destructuring Macros]]
 - [[#the-loopy-iter-macro][The ~loopy-iter~ Macro]]
@@ -2354,8 +2355,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     :DESCRIPTION: Immediately beginning the next iteration.
     :END:
 
-   #+findex: skip, continue
-    - =(skip|continue)= :: Go to next loop iteration.
+    #+findex: skip, continue
+    - =(skip|continue)= :: Go to the next loop iteration.
 
       #+BEGIN_SRC emacs-lisp
         ;; => (2 4 6 8 12 14 16 18)
@@ -2366,6 +2367,21 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
                  (push-into my-collection i))
                (finally-return (nreverse my-collection)))
       #+END_SRC
+
+    #+findex: skip-from, continue-from
+    - =(skip-from|continue-from NAME)= :: Go to the next loop iteration of the
+      loop =NAME=.
+
+      #+BEGIN_SRC emacs-lisp
+        ;; => ((1 2 3) (7 8 9))
+        (loopy outer
+               (array i [(1 2 3) (4 5 6) (7 8 9)])
+               (loop (list j i)
+                     (if (= 5 j)
+                         (skip-from outer)))
+               (collect i))
+      #+END_SRC
+
 
 *** Early Exit
     :PROPERTIES:
@@ -2381,13 +2397,13 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
     will return a list of those values.  If no value is given, ~nil~ is
     returned.
 
-    The commands =leave=, =while=, and =until= leave the current loop without
-    forcing a returned value.  Unlike the =return= commands, they do not stop
-    the loop from returning implied return values, such as the collection in
-    their respective examples.
+    The commands =leave=, =leave-from=, =while=, and =until= leave the current
+    loop without forcing a returned value.  Unlike the =return= commands, they
+    do not stop the loop from returning any implied return values, such as the
+    collection in their respective examples.
 
     #+findex: leave
-    - =leave= :: Leave the current loop without forcing a return value.
+    - =(leave)= :: Leave the current loop without forcing a return value.
 
       #+begin_src emacs-lisp
         ;; => (1 2 3 4)
@@ -2395,6 +2411,21 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
                (if (= i 5)
                    (leave)
                  (collect i)))
+      #+end_src
+
+    #+findex: leave-from
+    - =(leave-from NAME)= :: Leave the loop =NAME= without forcing a return
+      value.  This command is equivalent to =(at NAME (leave))= ([[#sub-loops]]).
+
+      #+begin_src emacs-lisp
+        ;; => ([2 4] [6 8])
+        (loopy outer
+               (list i '([2 4] [6 8] [7 10]))
+               (sub-loop (array j i)
+                         (when (cl-oddp j)
+                           ;; Equivalent to `(at outer (leave))'
+                           (leave-from outer)))
+               (collect i))
       #+end_src
 
     #+findex: return loop command
@@ -2441,105 +2472,132 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
                (collect i))
       #+end_src
 
-** Sub-loops
+** Sub-Loops
    :PROPERTIES:
    :DESCRIPTION: Running a loop within a loop.
+   :CUSTOM_ID: sub-loops
    :END:
 
+   The following commands exist to properly handle sub-loops.  Depending on
+   one's needs, passing a ~loopy~ macro call to the =do= command can be
+   insufficient or signal an error, as the sub-loop's macro call is inserted
+   into super-loop's expansion literally.  This means that it cannot affect any
+   of the super-loop's generated code, such as variable declarations.  The
+   following commands do not have that problem, because their expansions are
+   processed during the expansion of the top-level macro.
+
+   #+begin_src emacs-lisp
+     ;; Raises an error:
+     (loopy outer
+            (list i '((1 2) (3 4) (5 6)))
+            (do (loopy (list j i)
+                       (when (= j 5)
+                         (leave-from outer))))
+            (collect i))
+
+     ;; Works as expected:
+     ;; => ((1 2) (3 4))
+     (loopy outer
+            (list i '((1 2) (3 4) (5 6)))
+            (sub-loop (list j i)
+                      (when (= j 5)
+                        (leave-from outer)))
+            (collect i))
+
+   #+end_src
+
+
    #+findex: sub-loop, subloop, loop
-   - =(sub-loop|subloop|loop [CMDS])= :: Create a sub-loop in the same lexical
-     environment as the top-level loop.
+   - =(sub-loop|subloop|loop [SPECIAL-MACRO-ARGUMENTS] [CMDS])= :: Create a
+     sub-loop in the same lexical environment as the top-level loop, processing
+     sub-commands during the top-level loop's expansion.
 
+     This command is a wrapped form of the ~loopy~ macro, and so supports all of
+     its features, including special macro arguments.  When using ~loopy-iter~
+     ([[#loopy-iter]]), this command wraps the ~loopy-iter~ macro instead.
 
-   There are two main ways to have a sub-loop in ~loopy~:
+     #+begin_src emacs-lisp
+       ;; => ((2 4) (6 8) (10 12))
+       (loopy outer
+              (array i [(2 4) (6 8) (1 3) (10 12)])
+              (sub-loop (list j i)
+                        (when (cl-oddp j)
+                          (skip-from outer)))
+              (collect i))
+     #+end_src
 
-   1. Use another ~loopy~ call in a =do= command.
-   2. Use the =sub-loop= (aliases =loop= and =subloop=) command.
+   #+findex: at
+   - =(at LOOP-NAME [CMDS])= :: Parse some commands with respect to =LOOP-NAME=.
+     For example, a =leave= subcommand would exit the loop =LOOP-NAME=, and an
+     accumulation command would create a variable in that super-loop.
 
-   =sub-loop= is better for accumulating into variables, as is does not create
-   its own result variable (unlike calling ~loopy~ again).  When using the
-   =sub-loop= command, keep in mind the following:
+     If you did not use =at= in the below example, then the accumulation would
+     be local to the sub-loop and the macro's return value would be ~nil~.
 
-   1. Only loop commands are valid within a sub-loop, not special macro
-      arguments like =with= or =finally-return=.
+     #+begin_src emacs-lisp
+       ;; => (4 5 10 11 16 17)
+       (loopy outer
+              (array i [(1 2) (3 4) (5 6)])
+              (sub-loop (with (sum (apply #'+ i)))
+                        (list j i)
+                        (at outer (collect (+ sum j)))))
+     #+end_src
 
-      #+begin_src emacs-lisp
-        ;; GOOD:
-        ;; => (8 9 10)
-        (loopy (with (a 7))
-               (repeat 1)
-               (loop (list i '(1 2 3))
-                     (collect (+ a i))))
+   #+findex: loopy command
+   - =(loopy [SPECIAL-MACRO-ARGUMENTS] [CMDS])= :: Specifically wrap a call to
+     the ~loopy~ macro.  Unlike the =sub-loop= command, the behavior of this
+     command never changes.
 
-        ;; BAD:
-        (loopy (repeat 1)
-               (loop (with (a 7))
-                     (list i '(1 2 3))
-                     (collect (+ a i))))
-      #+end_src
+   #+findex: loopy-iter command
+   - =(loopy-iter [SPECIAL-MACRO-ARGUMENTS] [BODY])= :: Specifically wrap a call
+     to the ~loopy-iter~ macro ([[#loopy-iter]]).  Unlike the =sub-loop= command,
+     the behavior of this command never changes.
 
-   2. Sub-loops can be named, but they do not have their own return value. The
-      default loop name in ~loopy~ is ~nil~ for the top-level loop, but not for
-      sub-loops.  To return from the outer loop, you can use =return-from=.
+     This feature can only be used after first loading the library =loopy-iter=.
 
-      #+begin_src emacs-lisp
-        ;; Return from inner1 so never reach 4.
-        ;; => ((3 5) (3 5))
-        (loopy (repeat 2)
-               (loop inner1
-                     (list j '(3 4))
-                     (loop (list k '(5 6 7))
-                           (if (= k 6)
-                               (return-from inner1)
-                             (collect (list j k))))))
+     #+begin_src elisp
+       (require 'loopy-iter)
 
-        ;; Can use `return-from' on `nil' to refer to the
-        ;; top-level loop, if un-named. Otherwise use the name.
-        (loopy (list i '(1 2 3))
-               (loop (list j '(5 4 3))
-                     (if (= i j)
-                         (return-from nil i)
-                       (collect (cons i j)))))
-      #+end_src
+       ;; => '(11 12 13 14 15 16)
+       (loopy outer
+              (list i '((1 2) (3 4) (5 6)))
+              (loopy-iter (for list j i)
+                          (for at outer
+                               (let ((val 10))
+                                 (accum collect (+ val j))))))
+     #+end_src
 
-      Because there is no return value for sub-loops, the =return= and =leave=
-      commands behave similarly.
+   Keep in mind that the effects of flags ([[#flags]]) are local to the loops in
+   which they are used, even when using the =at= command.
 
-      #+begin_src emacs-lisp
-        ;; => ((1 .6) (2 . 6))
-        (loopy (list i '(1 2))
-               (loop (list j '(6 7 8))
-                     (if (= j 7)
-                         (return)
-                       (collect (cons i j)))))
+   #+begin_src emacs-lisp
+     ;; => ((1 2 11 12)
+     ;;     ((2) (3) (12) (13)))
+     (loopy outer
+            (flag pcase)
+            (array elem [(1 2) (11 12)])
+            (collect `(,first . ,rest) elem)
+            ;; NOTE: The sub-loop uses the default destructuring style.
+            ;;       The `pcase' style only affects the surrounding loop.
+            (sub-loop (at outer (collect (first &rest rest) (mapcar #'1+ elem)))
+                      (leave))
+            (finally-return first rest))
 
-        ;; => ((1 .6) (2 . 6))
-        (loopy (list i '(1 2))
-               (loop (list j '(6 7 8))
-                     (if (= j 7)
-                         (leave)
-                       (collect (cons i j)))))
-      #+end_src
+     ;; => (((1 2) (3 4))
+     ;;     (cat cat)
+     ;;     (1 dog 2 dog 3 dog 4 dog))
+     (loopy outer
+            (flag split)
+            (list i '((1 2) (3 4)))
+            (collect i)
+            (collect 'cat)
+            (loop (list j i)
+                  ;; NOTE: These variables not split.
+                  (at outer
+                      (collect j)
+                      (collect 'dog))))
+   #+end_src
 
-   3. Variables used for iteration can be local to a sub-loop, but not
-      variables used for accumulation.
-
-      #+begin_src emacs-lisp
-        ;; GOOD:
-        ;; => (0 1 2 3 1 2 3)
-        (loopy (repeat 2)
-               (loop (list i '(1 2 3))
-                     (collect my-coll i))
-               (finally-return (cons 0 my-coll)))
-
-        ;; BAD:
-        ;; Would not give (0 3 3).  Instead, signals error.
-        (loopy (repeat 2)
-               (loop (list i '(1 2 3)))
-               ;; Error:  `i' doesn't exist outside the sub-loop:
-               (collect my-coll i)
-               (finally-return (cons 0 my-coll)))
-      #+end_src
 
 * Special Variables
   :PROPERTIES:
@@ -2597,6 +2655,17 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
         (list a b c k1 k2 k3))
     #+end_src
 
+  #+findex: loopy-lambda
+  - ~loopy-lambda~ :: Use destructuring in a ~lambda~'s argument list.
+
+    #+begin_src emacs-lisp
+      ;; => ((1 2 :k1 3) 110)
+      (funcall (loopy-lambda ((&whole first-arg a b &key k1 (k2 4))
+                              second-arg)
+                 (list first-arg (+ a b k1 k2 second-arg)))
+               (list 1 2 :k1 3) 100)
+    #+end_src
+
   #+findex: loopy-ref
   - ~loopy-ref~ :: Create destructured references to the fields in a sequence
     via ~cl-symbol-macrolet~.  This is not to be confused with ~cl-letf~, which
@@ -2636,7 +2705,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   #+attr_texinfo: :tag Warning
   #+begin_quote
   *This feature is still experimental.*  It might not work correctly in all
-  circumstances.
+  circumstances.  Please report any problems you come across on this project's
+  [[https://github.com/okamsn/loopy/issues][issues tracker]].
   #+end_quote
 
   This macro is meant to be conceptually similar to the ~iterate~ or ~iter~
@@ -2737,6 +2807,21 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
                          elem))
   #+end_src
 
+  In ~loopy~, the =sub-loop= command is a full ~loopy~ loop.  In ~loopy-iter~,
+  it is a full ~loopy-iter~ loop.
+
+  #+begin_src emacs-lisp
+    ;; => (2 3 4 5)
+    (loopy-iter outer
+                (for list i '([1 2] [3 4]))
+                (for loop
+                     ;; NOTE: `loopy-iter' style, not `loopy' style
+                     (for array j i)
+                     (for at outer
+                          (let ((val (1+ j)))
+                            (accum collect val)))))
+  #+end_src
+
   #+attr_texinfo: :tag Note
   #+begin_quote
   Nesting arbitrary code in the loop requires knowing how to understand the
@@ -2746,8 +2831,8 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
   #+end_quote
 
   ~loopy~ (and so ~loopy-iter~) does not currently have all of the features of
-  Common Lisp's ~iter~ macro.  Think of it more as a way to use loop commands
-  embedded in arbitrary code.
+  Common Lisp's ~iter~ macro.  Think of it more as an alternative form of
+  ~loopy~ instead of a port of ~iter~.
 
 
 * Using Flags
@@ -4054,4 +4139,4 @@ and =cl-lib= ([[info:cl]]) libraries and Emacs's regular looping and mapping fea
 # toc-org-max-depth: 20
 # End:
 
-#  LocalWords:  alists plists
+#  LocalWords:  alists plists Loopy's

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -27,9 +27,9 @@
 @code{cl-loop} (@ref{Loop Facility,,,cl,}) but uses symbolic expressions rather than
 keywords.
 
-For most use cases, @code{loopy} should a nice substitute for @code{cl-loop} and
-complementary to the features provided by the @samp{seq} (@ref{Sequence Functions,,,elisp,})
-and @samp{cl-lib} (@ref{Top,,,cl,}) libraries and Emacs's regular looping and mapping features.
+For most use cases, @code{loopy} should be a nice substitute for @code{cl-loop} and
+complementary to the features provided by the @samp{seq} (@ref{Sequence Functions,,,elisp,}) and @samp{cl-lib} (@ref{Top,,,cl,}) libraries and Emacs's regular looping and
+mapping features.
 
 @end ifnottex
 
@@ -61,7 +61,7 @@ Loop Commands
 * Accumulation::                 Accumulating values into new sequences, aggregating values, etc.
 * Boolean::                      Testing whether a condition holds true.
 * Control Flow::                 When to run loop commands.
-* Sub-loops::                    Running a loop within a loop.
+* Sub-Loops::                    Running a loop within a loop.
 
 Iteration
 
@@ -233,7 +233,7 @@ attempt to interpret it as a loop command, and throw an error if that fails.
 
 These special macro arguments are always processed before loop commands,
 regardless of the order of the arguments passed to @code{loopy}.  As they are not
-loop commands, they cannot occur in sub-loops (@ref{Sub-loops}).
+loop commands, they cannot occur in sub-loops ([BROKEN LINK: *Sub-loops]).
 
 @findex with, let*
 @table @asis
@@ -518,7 +518,7 @@ attempting to do something like the below example might not do what you
 expect, as @samp{i} is assigned a value from the list after collecting @samp{i} into
 @samp{coll}.
 
-@float Listing,orgb094664
+@float Listing,orga2e4473
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -704,7 +704,7 @@ destructuring.  They are explained more in their respective sections.
 * Accumulation::                 Accumulating values into new sequences, aggregating values, etc.
 * Boolean::                      Testing whether a condition holds true.
 * Control Flow::                 When to run loop commands.
-* Sub-loops::                    Running a loop within a loop.
+* Sub-Loops::                    Running a loop within a loop.
 @end menu
 
 @node Generic Evaluation
@@ -2547,7 +2547,7 @@ non-nil, run the following commands @samp{CMDS}.
 @findex skip, continue
 @table @asis
 @item @samp{(skip|continue)}
-Go to next loop iteration.
+Go to the next loop iteration.
 
 @lisp
 ;; => (2 4 6 8 12 14 16 18)
@@ -2557,6 +2557,23 @@ Go to next loop iteration.
        (when (cl-evenp i)
          (push-into my-collection i))
        (finally-return (nreverse my-collection)))
+@end lisp
+@end table
+
+@findex skip-from, continue-from
+@table @asis
+@item @samp{(skip-from|continue-from NAME)}
+Go to the next loop iteration of the
+loop @samp{NAME}.
+
+@lisp
+;; => ((1 2 3) (7 8 9))
+(loopy outer
+       (array i [(1 2 3) (4 5 6) (7 8 9)])
+       (loop (list j i)
+             (if (= 5 j)
+                 (skip-from outer)))
+       (collect i))
 @end lisp
 @end table
 
@@ -2571,14 +2588,14 @@ If multiple values are passed to @samp{return} or @samp{return-from}, these comm
 will return a list of those values.  If no value is given, @code{nil} is
 returned.
 
-The commands @samp{leave}, @samp{while}, and @samp{until} leave the current loop without
-forcing a returned value.  Unlike the @samp{return} commands, they do not stop
-the loop from returning implied return values, such as the collection in
-their respective examples.
+The commands @samp{leave}, @samp{leave-from}, @samp{while}, and @samp{until} leave the current
+loop without forcing a returned value.  Unlike the @samp{return} commands, they
+do not stop the loop from returning any implied return values, such as the
+collection in their respective examples.
 
 @findex leave
 @table @asis
-@item @samp{leave}
+@item @samp{(leave)}
 Leave the current loop without forcing a return value.
 
 @lisp
@@ -2587,6 +2604,24 @@ Leave the current loop without forcing a return value.
        (if (= i 5)
            (leave)
          (collect i)))
+@end lisp
+@end table
+
+@findex leave-from
+@table @asis
+@item @samp{(leave-from NAME)}
+Leave the loop @samp{NAME} without forcing a return
+value.  This command is equivalent to @samp{(at NAME (leave))} (@ref{Sub-Loops}).
+
+@lisp
+;; => ([2 4] [6 8])
+(loopy outer
+       (list i '([2 4] [6 8] [7 10]))
+       (sub-loop (array j i)
+                 (when (cl-oddp j)
+                   ;; Equivalent to `(at outer (leave))'
+                   (leave-from outer)))
+       (collect i))
 @end lisp
 @end table
 
@@ -2646,115 +2681,140 @@ return value.
 @end lisp
 @end table
 
-@node Sub-loops
-@section Sub-loops
+@node Sub-Loops
+@section Sub-Loops
+
+The following commands exist to properly handle sub-loops.  Depending on
+one's needs, passing a @code{loopy} macro call to the do command can be
+insufficient or signal an error, as the sub-loop's macro call is inserted
+into super-loop's expansion literally.  This means that it cannot affect any
+of the super-loop's generated code, such as variable declarations.  The
+following commands do not have that problem, because their expansions are
+processed during the expansion of the top-level macro.
+
+@lisp
+;; Raises an error:
+(loopy outer
+       (list i '((1 2) (3 4) (5 6)))
+       (do (loopy (list j i)
+                  (when (= j 5)
+                    (leave-from outer))))
+       (collect i))
+
+;; Works as expected:
+;; => ((1 2) (3 4))
+(loopy outer
+       (list i '((1 2) (3 4) (5 6)))
+       (sub-loop (list j i)
+                 (when (= j 5)
+                   (leave-from outer)))
+       (collect i))
+
+@end lisp
+
 
 @findex sub-loop, subloop, loop
 @table @asis
-@item @samp{(sub-loop|subloop|loop [CMDS])}
-Create a sub-loop in the same lexical
-environment as the top-level loop.
+@item @samp{(sub-loop|subloop|loop [SPECIAL-MACRO-ARGUMENTS] [CMDS])}
+Create a
+sub-loop in the same lexical environment as the top-level loop, processing
+sub-commands during the top-level loop's expansion.
+
+This command is a wrapped form of the @code{loopy} macro, and so supports all of
+its features, including special macro arguments.  When using @code{loopy-iter}
+(@ref{The @code{loopy-iter} Macro}), this command wraps the @code{loopy-iter} macro instead.
+
+@lisp
+;; => ((2 4) (6 8) (10 12))
+(loopy outer
+       (array i [(2 4) (6 8) (1 3) (10 12)])
+       (sub-loop (list j i)
+                 (when (cl-oddp j)
+                   (skip-from outer)))
+       (collect i))
+@end lisp
 @end table
 
+@findex at
+@table @asis
+@item @samp{(at LOOP-NAME [CMDS])}
+Parse some commands with respect to @samp{LOOP-NAME}.
+For example, a @samp{leave} subcommand would exit the loop @samp{LOOP-NAME}, and an
+accumulation command would create a variable in that super-loop.
 
-There are two main ways to have a sub-loop in @code{loopy}:
-
-@enumerate
-@item
-Use another @code{loopy} call in a @samp{do} command.
-@item
-Use the @samp{sub-loop} (aliases @samp{loop} and @samp{subloop}) command.
-@end enumerate
-
-@samp{sub-loop} is better for accumulating into variables, as is does not create
-its own result variable (unlike calling @code{loopy} again).  When using the
-@samp{sub-loop} command, keep in mind the following:
-
-@enumerate
-@item
-Only loop commands are valid within a sub-loop, not special macro
-arguments like @samp{with} or @samp{finally-return}.
+If you did not use @samp{at} in the below example, then the accumulation would
+be local to the sub-loop and the macro's return value would be @code{nil}.
 
 @lisp
-;; GOOD:
-;; => (8 9 10)
-(loopy (with (a 7))
-       (repeat 1)
-       (loop (list i '(1 2 3))
-             (collect (+ a i))))
-
-;; BAD:
-(loopy (repeat 1)
-       (loop (with (a 7))
-             (list i '(1 2 3))
-             (collect (+ a i))))
+;; => (4 5 10 11 16 17)
+(loopy outer
+       (array i [(1 2) (3 4) (5 6)])
+       (sub-loop (with (sum (apply #'+ i)))
+                 (list j i)
+                 (at outer (collect (+ sum j)))))
 @end lisp
+@end table
 
-@item
-Sub-loops can be named, but they do not have their own return value. The
-default loop name in @code{loopy} is @code{nil} for the top-level loop, but not for
-sub-loops.  To return from the outer loop, you can use @samp{return-from}.
+@findex loopy command
+@table @asis
+@item @samp{(loopy [SPECIAL-MACRO-ARGUMENTS] [CMDS])}
+Specifically wrap a call to
+the @code{loopy} macro.  Unlike the @samp{sub-loop} command, the behavior of this
+command never changes.
+@end table
+
+@findex loopy-iter command
+@table @asis
+@item @samp{(loopy-iter [SPECIAL-MACRO-ARGUMENTS] [BODY])}
+Specifically wrap a call
+to the @code{loopy-iter} macro (@ref{The @code{loopy-iter} Macro}).  Unlike the @samp{sub-loop} command,
+the behavior of this command never changes.
+
+This feature can only be used after first loading the library @samp{loopy-iter}.
 
 @lisp
-;; Return from inner1 so never reach 4.
-;; => ((3 5) (3 5))
-(loopy (repeat 2)
-       (loop inner1
-             (list j '(3 4))
-             (loop (list k '(5 6 7))
-                   (if (= k 6)
-                       (return-from inner1)
-                     (collect (list j k))))))
+(require 'loopy-iter)
 
-;; Can use `return-from' on `nil' to refer to the
-;; top-level loop, if un-named. Otherwise use the name.
-(loopy (list i '(1 2 3))
-       (loop (list j '(5 4 3))
-             (if (= i j)
-                 (return-from nil i)
-               (collect (cons i j)))))
+;; => '(11 12 13 14 15 16)
+(loopy outer
+       (list i '((1 2) (3 4) (5 6)))
+       (loopy-iter (for list j i)
+                   (for at outer
+                        (let ((val 10))
+                          (accum collect (+ val j))))))
 @end lisp
+@end table
 
-Because there is no return value for sub-loops, the @samp{return} and @samp{leave}
-commands behave similarly.
+Keep in mind that the effects of flags (@ref{Using Flags}) are local to the loops in
+which they are used, even when using the @samp{at} command.
 
 @lisp
-;; => ((1 .6) (2 . 6))
-(loopy (list i '(1 2))
-       (loop (list j '(6 7 8))
-             (if (= j 7)
-                 (return)
-               (collect (cons i j)))))
+;; => ((1 2 11 12)
+;;     ((2) (3) (12) (13)))
+(loopy outer
+       (flag pcase)
+       (array elem [(1 2) (11 12)])
+       (collect `(,first . ,rest) elem)
+       ;; NOTE: The sub-loop uses the default destructuring style.
+       ;;       The `pcase' style only affects the surrounding loop.
+       (sub-loop (at outer (collect (first &rest rest) (mapcar #'1+ elem)))
+                 (leave))
+       (finally-return first rest))
 
-;; => ((1 .6) (2 . 6))
-(loopy (list i '(1 2))
-       (loop (list j '(6 7 8))
-             (if (= j 7)
-                 (leave)
-               (collect (cons i j)))))
+;; => (((1 2) (3 4))
+;;     (cat cat)
+;;     (1 dog 2 dog 3 dog 4 dog))
+(loopy outer
+       (flag split)
+       (list i '((1 2) (3 4)))
+       (collect i)
+       (collect 'cat)
+       (loop (list j i)
+             ;; NOTE: These variables not split.
+             (at outer
+                 (collect j)
+                 (collect 'dog))))
 @end lisp
-
-@item
-Variables used for iteration can be local to a sub-loop, but not
-variables used for accumulation.
-
-@lisp
-;; GOOD:
-;; => (0 1 2 3 1 2 3)
-(loopy (repeat 2)
-       (loop (list i '(1 2 3))
-             (collect my-coll i))
-       (finally-return (cons 0 my-coll)))
-
-;; BAD:
-;; Would not give (0 3 3).  Instead, signals error.
-(loopy (repeat 2)
-       (loop (list i '(1 2 3)))
-       ;; Error:  `i' doesn't exist outside the sub-loop:
-       (collect my-coll i)
-       (finally-return (cons 0 my-coll)))
-@end lisp
-@end enumerate
 
 @node Special Variables
 @chapter Special Variables
@@ -2815,6 +2875,20 @@ Use destructuring in a @code{setq} form.
 @end lisp
 @end table
 
+@findex loopy-lambda
+@table @asis
+@item @code{loopy-lambda}
+Use destructuring in a @code{lambda}'s argument list.
+
+@lisp
+;; => ((1 2 :k1 3) 110)
+(funcall (loopy-lambda ((&whole first-arg a b &key k1 (k2 4))
+                        second-arg)
+           (list first-arg (+ a b k1 k2 second-arg)))
+         (list 1 2 :k1 3) 100)
+@end lisp
+@end table
+
 @findex loopy-ref
 @table @asis
 @item @code{loopy-ref}
@@ -2852,7 +2926,8 @@ arbitrary code in a loop.  You must use @code{require} to load this feature.
 
 @quotation Warning
 @strong{This feature is still experimental.}  It might not work correctly in all
-circumstances.
+circumstances.  Please report any problems you come across on this project's
+@uref{https://github.com/okamsn/loopy/issues, issues tracker}.
 
 @end quotation
 
@@ -2954,6 +3029,21 @@ seen by @code{loopy-iter}.
                      elem))
 @end lisp
 
+In @code{loopy}, the @samp{sub-loop} command is a full @code{loopy} loop.  In @code{loopy-iter},
+it is a full @code{loopy-iter} loop.
+
+@lisp
+;; => (2 3 4 5)
+(loopy-iter outer
+            (for list i '([1 2] [3 4]))
+            (for loop
+                 ;; NOTE: `loopy-iter' style, not `loopy' style
+                 (for array j i)
+                 (for at outer
+                      (let ((val (1+ j)))
+                        (accum collect val)))))
+@end lisp
+
 @quotation Note
 Nesting arbitrary code in the loop requires knowing how to understand the
 code.  You might find cases where @code{loopy-iter} interprets code incorrectly.
@@ -2963,8 +3053,8 @@ Please report such cases on this project's @uref{https://github.com/okamsn/loopy
 @end quotation
 
 @code{loopy} (and so @code{loopy-iter}) does not currently have all of the features of
-Common Lisp's @code{iter} macro.  Think of it more as a way to use loop commands
-embedded in arbitrary code.
+Common Lisp's @code{iter} macro.  Think of it more as an alternative form of
+@code{loopy} instead of a port of @code{iter}.
 
 @node Using Flags
 @chapter Using Flags

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -54,12 +54,9 @@
 ;;; Code:
 (require 'loopy)
 (require 'loopy-misc)
+(require 'loopy-vars)
 (require 'dash)
 (require 'cl-lib)
-
-(defvar loopy--destructuring-accumulation-parser)
-(defvar loopy--destructuring-for-with-vars-function)
-(defvar loopy--flag-settings nil)
 
 (defun loopy-dash--enable-flag-dash ()
   "Make this `loopy' loop use Dash destructuring."

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -712,6 +712,19 @@ See `loopy--destructure-list' for normal values."
     ;; Fix the order of the bindings and return.
     (nreverse bindings)))
 
+;;;; Loop Tag Names
+(defun loopy--produce-non-returning-exit-tag-name (&optional loop-name)
+  "Produce a tag from LOOP-NAME."
+  (if loop-name
+      (intern (format "loopy--%s-non-returning-exit-tag" loop-name))
+    'loopy--non-returning-exit-tag))
+
+
+(defun loopy--produce-skip-tag-name (&optional loop-name)
+  "Produce a tag from LOOP-NAME."
+  (if loop-name
+      (intern (format "loopy-%s-skip-tag"  loop-name))
+    'loopy--skip-tag))
 
 (provide 'loopy-misc)
 ;;; loopy-misc.el ends here

--- a/loopy-pcase.el
+++ b/loopy-pcase.el
@@ -40,13 +40,10 @@
 ;;; Code:
 (require 'loopy)
 (require 'loopy-misc)
+(require 'loopy-vars)
 (require 'macroexp)
 (require 'pcase)
 (require 'cl-lib)
-
-(defvar loopy--destructuring-for-with-vars-function)
-(defvar loopy--destructuring-accumulation-parser)
-(defvar loopy--flag-settings nil)
 
 (defun loopy-pcase--enable-flag-pcase ()
   "Make this `loopy' loop use `pcase' destructuring."

--- a/loopy-seq.el
+++ b/loopy-seq.el
@@ -46,15 +46,12 @@
 
 (require 'loopy)
 (require 'loopy-misc)
+(require 'loopy-vars)
 (require 'seq)
 (require 'pcase)
 (require 'loopy-pcase)
 (require 'macroexp)
 (require 'cl-lib)
-
-(defvar loopy--destructuring-for-with-vars-function)
-(defvar loopy--destructuring-accumulation-parser)
-(defvar loopy--flag-settings nil)
 
 (defun loopy-seq--enable-flag-seq ()
   "Make this `loopy' loop use `seq-let' destructuring."

--- a/loopy-vars.el
+++ b/loopy-vars.el
@@ -1,0 +1,688 @@
+;;; loopy-vars.el --- Variables used by Loopy -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2021 Earl Hyatt
+
+;; Author: Earl Hyatt
+;; Created: August 2021
+;; URL: https://github.com/okamsn/loopy
+;; Version: 0.8.1
+;; Package-Requires: ((emacs "27.1") (loopy "0.8.1"))
+;; Keywords: extensions
+;; LocalWords:  Loopy's emacs alists
+
+;;; Disclaimer:
+;; This file is not part of GNU Emacs.
+;;
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this file.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; `loopy' is a macro that is used similarly to `cl-loop'.  It provides "loop
+;; commands" that define a loop body and it's surrounding environment, as well
+;; as exit conditions.
+;;
+;; This file provides the package's user options and the variables `loopy' uses
+;; for macro expansion and running the loop.
+;;
+;; For more information, see this package's Info documentation under Info node
+;; `(loopy)'.
+
+;;; Code:
+
+(require 'map)
+(require 'cl-lib)
+(require 'seq)
+
+;;;; User Options
+(defgroup loopy nil
+  "A looping and iteration macro."
+  :group 'tools
+  :prefix "loopy-"
+  :link '(url-link "https://github.com/okamsn/loopy"))
+
+(defcustom loopy-default-flags nil
+  "Which flags should alter the behavior of `loopy' by default.
+
+This is a list of symbols, each symbol corresponding to a
+function in the variable `loopy--flag-settings'."
+  :type '(repeat symbol))
+
+;;;###autoload
+(defalias 'loopy-custom-command-aliases 'loopy-command-aliases)
+(defcustom loopy-command-aliases nil
+  "An alist of pairs of a quoted alias and a quoted true name.
+
+For example, to create the alias `add' for the command `sum', one would add
+
+  '(add . sum)
+
+to this list.  Aliases can also be defined for the special macro
+arguments, such as `with' or `before-do'.
+
+ This user option is an alternative to modifying
+`loopy-command-parsers' when the command parser is unknown."
+  :group 'loopy
+  :type '(alist :key-type symbol :value-type symbol))
+
+;;;###autoload
+(defalias 'loopy-custom-command-parsers 'loopy-command-parsers)
+
+;;;###autoload
+(defcustom loopy-command-parsers
+  ;; Plenty of these are just aliases.
+  '((accumulate   . loopy--parse-accumulate-command)
+    (accumulating . loopy--parse-accumulate-command)
+    (always       . loopy--parse-always-command)
+    (append       . loopy--parse-append-command)
+    (appending    . loopy--parse-append-command)
+    (across       . loopy--parse-array-command)
+    (across-ref   . loopy--parse-array-ref-command)
+    (adjoin       . loopy--parse-adjoin-command)
+    (adjoining    . loopy--parse-adjoin-command)
+    (array        . loopy--parse-array-command)
+    (array-index  . loopy--parse-seq-index-command)
+    (arrayi       . loopy--parse-seq-index-command)
+    (array-ref    . loopy--parse-array-ref-command)
+    (arrayf       . loopy--parse-array-ref-command)
+    (at           . loopy--parse-at-command)
+    (callf        . loopy--parse-reduce-command)
+    (callf2       . loopy--parse-accumulate-command)
+    (collect      . loopy--parse-collect-command)
+    (collecting   . loopy--parse-collect-command)
+    (command-do   . loopy--parse-group-command)
+    (concat       . loopy--parse-concat-command)
+    (concating    . loopy--parse-concat-command)
+    (cond         . loopy--parse-cond-command)
+    (cons         . loopy--parse-cons-command)
+    (conses       . loopy--parse-cons-command)
+    (continue     . loopy--parse-skip-command)
+    (continue-from . loopy--parse-skip-from-command)
+    (count        . loopy--parse-count-command)
+    (counting     . loopy--parse-count-command)
+    (do           . loopy--parse-do-command)
+    (each         . loopy--parse-list-command)
+    (elements     . loopy--parse-seq-command)
+    (elements-ref . loopy--parse-seq-ref-command)
+    (expr         . loopy--parse-expr-command)
+    (exprs        . loopy--parse-expr-command)
+    (find         . loopy--parse-find-command)
+    (finding      . loopy--parse-find-command)
+    (group        . loopy--parse-group-command)
+    (if           . loopy--parse-if-command)
+    (in           . loopy--parse-list-command)
+    (in-ref       . loopy--parse-list-ref-command)
+    (leave        . loopy--parse-leave-command)
+    (leave-from   . loopy--parse-leave-from-command)
+    (list         . loopy--parse-list-command)
+    (list-index  . loopy--parse-seq-index-command)
+    (listi       . loopy--parse-seq-index-command)
+    (list-ref     . loopy--parse-list-ref-command)
+    (listf        . loopy--parse-list-ref-command)
+    (loop         . loopy--parse-sub-loop-command)
+    (loopy        . loopy--parse-loopy-command)
+    (map          . loopy--parse-map-command)
+    (map-pairs    . loopy--parse-map-command)
+    (map-ref      . loopy--parse-map-ref-command)
+    (mapf         . loopy--parse-map-ref-command)
+    (max          . loopy--parse-max-command)
+    (maxing       . loopy--parse-max-command)
+    (maximize     . loopy--parse-max-command)
+    (maximizing   . loopy--parse-max-command)
+    (min          . loopy--parse-min-command)
+    ;; Unlike "maxing", there doesn't seem to be much on-line about the word
+    ;; "minning", but the double-N follows conventional spelling rules, such as
+    ;; in "sum" and "summing".
+    (minning      . loopy--parse-min-command)
+    (minimize     . loopy--parse-min-command)
+    (minimizing   . loopy--parse-min-command)
+    (multiply     . loopy--parse-multiply-command)
+    (multiplying  . loopy--parse-multiply-command)
+    (never        . loopy--parse-never-command)
+    (nconc        . loopy--parse-nconc-command)
+    (nconcing     . loopy--parse-nconc-command)
+    (num          . loopy--parse-nums-command)
+    (number       . loopy--parse-nums-command)
+    (nums         . loopy--parse-nums-command)
+    (numbers      . loopy--parse-nums-command)
+    (numup        . loopy--parse-nums-up-command)
+    (numsup       . loopy--parse-nums-up-command)
+    (num-up       . loopy--parse-nums-up-command)
+    (number-up    . loopy--parse-nums-up-command)
+    (nums-up      . loopy--parse-nums-up-command)
+    (numbers-up   . loopy--parse-nums-up-command)
+    (numdown      . loopy--parse-nums-down-command)
+    (numsdown     . loopy--parse-nums-down-command)
+    (num-down     . loopy--parse-nums-down-command)
+    (number-down  . loopy--parse-nums-down-command)
+    (nums-down    . loopy--parse-nums-down-command)
+    (numbers-down . loopy--parse-nums-down-command)
+    (nunion       . loopy--parse-nunion-command)
+    (nunioning    . loopy--parse-nunion-command)
+    (on           . loopy--parse-cons-command)
+    (prepend      . loopy--parse-prepend-command)
+    (prepending   . loopy--parse-prepend-command)
+    (prev         . loopy--parse-prev-expr-command)
+    (prev-expr    . loopy--parse-prev-expr-command)
+    (push         . loopy--parse-push-into-command)
+    (pushing      . loopy--parse-push-into-command)
+    (push-into    . loopy--parse-push-into-command)
+    (pushing-into . loopy--parse-push-into-command)
+    (reduce       . loopy--parse-reduce-command)
+    (reducing     . loopy--parse-reduce-command)
+    (repeat       . loopy--parse-repeat-command)
+    (return       . loopy--parse-return-command)
+    (return-from  . loopy--parse-return-from-command)
+    (seq          . loopy--parse-seq-command)
+    (seq-index    . loopy--parse-seq-index-command)
+    (seqi         . loopy--parse-seq-index-command)
+    (seq-ref      . loopy--parse-seq-ref-command)
+    (seqf         . loopy--parse-seq-ref-command)
+    (sequence     . loopy--parse-seq-command)
+    (sequencef    . loopy--parse-seq-ref-command)
+    (set          . loopy--parse-expr-command)
+    (skip         . loopy--parse-skip-command)
+    (skip-from     . loopy--parse-skip-from-command)
+    (string       . loopy--parse-array-command)
+    (string-index . loopy--parse-seq-index-command)
+    (stringi      . loopy--parse-seq-index-command)
+    (string-ref   . loopy--parse-array-ref-command)
+    (stringf      . loopy--parse-array-ref-command)
+    (subloop      . loopy--parse-sub-loop-command)
+    (sub-loop     . loopy--parse-sub-loop-command)
+    (sum          . loopy--parse-sum-command)
+    (summing      . loopy--parse-sum-command)
+    (thereis      . loopy--parse-thereis-command)
+    (union        . loopy--parse-union-command)
+    (unioning     . loopy--parse-union-command)
+    (unless       . loopy--parse-when-unless-command)
+    (until        . loopy--parse-while-until-commands)
+    (vconcat      . loopy--parse-vconcat-command)
+    (vconcating   . loopy--parse-vconcat-command)
+    (when         . loopy--parse-when-unless-command)
+    (while        . loopy--parse-while-until-commands))
+  "An alist of pairs of a quoted command name and a parsing function.
+
+The parsing function is chosen based on the command name (such as
+`list' in `(list i my-list)'), not the usage of the command.  That is,
+
+  (my-command var1)
+
+and
+
+  (my-command var1 var2)
+
+are both parsed by the same function, but that parsing function
+is not limited in how it responds to different usages.  If you
+really want, it can return different instructions each time.
+Learn more with `(info \"(emacs)loopy\")'.
+
+For example, to add a `when' command (if one didn't already
+exist), one could do
+
+  (add-to-list \'loopy-command-parsers
+                (cons 'when #'my-loopy-parse-when-command))"
+  :group 'loopy
+  :type '(alist :key-type symbol :value-type function))
+
+
+
+;;;; Flags
+;;;;; Variables that can be set by flags
+(defvar loopy--split-implied-accumulation-results nil
+  "Whether implicit accumulation commands should use separate variables.
+
+Nil means that each accumulation command without a named
+accumulation variable should accumulate into the same variable,
+by default named `loopy-result'.")
+
+(defvar loopy--destructuring-for-with-vars-function nil
+  "The function used for destructuring `with' variables.
+
+This function named by this variables receives the bindings given
+to the `with' macro argument and should usually return a list of
+two elements:
+
+1. A function/macro that works like `let*' and can be used to wrap
+   the expanded macro code.
+2. The bindings that will be given to this macro.
+
+For example, an acceptable return value might be something like
+
+    (list 'pcase-let* BINDINGS)
+
+which will be used to wrap the loop and other code.
+
+If nil, use `loopy--destructure-for-with-vars-default'.")
+
+(defvar loopy--destructuring-for-iteration-function nil
+  "The function to use for destructuring during iteration commands.
+
+The function named by this variable receives a sequence of
+variable names and a value expression.  It should return an
+expression that can be used in the loop's main body and a list of
+variables which must be initialized in the loop.
+
+Generally, the main-body expression should use `setq' to assign
+to the variables found in the sequence of variable names, and the
+list of variables to initialize will include the variables in
+said sequence and any others that might leek through.
+
+If nil, use `loopy--destructure-for-iteration-default'.")
+
+(defvar loopy--destructuring-accumulation-parser nil
+  "The function used to parse destructuring accumulation commands.
+
+Unlike `loopy--destructuring-for-iteration-function', the
+function named by this variable returns instructions, not a list
+of variable-value pairs.
+
+If nil, use `loopy--parse-destructuring-accumulation-command'.")
+
+;;;;; For setting up flags
+(defvar loopy--flag-settings nil
+  "Alist of functions to run on presence of their respective flag.
+
+These functions will enable features.
+
+Each item is of the form (FLAG . FLAG-ENABLING-FUNCTION).")
+
+
+;;;; Special Macro Arguments
+;; These only set in the `loopy' macro, but that might change in the future.  It
+;; might be cleaner code to modify from the parsing function, after the macro
+;; has already set them to nil.
+
+(defvar loopy--valid-macro-arguments
+  '( flag flags with let* init without no-with no-init before-do before initially-do
+     initially after-do after else-do else finally-do finally finally-return wrap)
+  "List of valid keywords for `loopy' macro arguments.
+
+This variable is used to signal an error instead of silently failing.")
+
+(defvar loopy--loop-name nil
+  "A symbol that names the loop, appropriate for use in `cl-block'.")
+
+(defvar loopy--known-loop-names nil
+  "The stack of symbols of currently expanding loops.
+
+This is used to check for errors with the `at' command.")
+
+
+(defvar loopy--flags nil
+  "Symbols/flags whose presence changes the behavior of `loopy'.
+
+NOTE: This functionality might change in the future.")
+
+(defvar loopy--with-vars nil
+  "With Forms are variables explicitly created using the `with' keyword.
+
+This is a list of ((VAR1 VAL1) (VAR2 VAL2) ...).  If VAR is a
+sequence, then it will be destructured.  How VAR and VAL are
+used, as well as how the bindings are expanded into the loop's
+surrounding code, is determined by the destructuring system being
+used.
+
+They are created by passing (with (VAR1 VAL1) (VAR2 VAL2) ...) to
+`loopy'.")
+
+(defvar loopy--without-vars nil
+  "A list of variables that `loopy' won't try to initialize.
+
+`loopy' tries to initialize all variables that it uses in a
+`let'-like form, but this isn't always desired.
+
+This is used in `loopy--bound-p', and is of the form (VAR1 VAR2 ...).
+There are no values in this list, only variable names.")
+
+(defvar loopy--wrapping-forms nil
+  "Forms that should wrap the loop body, applied in order.
+
+A form can be either a list or a symbol.  If a list, the loop
+body is inserted into the end of the list.  If a symbol, the
+symbol is applied as a function to the loop body.  This is
+similar in use to the macros `thread-first' and `thread-last'.
+
+These forms fall under the variable definitions used by the
+loop (that is, they occur in the `let'-body instead of
+surrounding it).  Only the loop body is wrapped.  If you wish to
+wrap the return values and other parts of the macro expansion,
+just wrap the macro expression as you normally would.")
+
+(defvar loopy--before-do nil
+  "A list of expressions to evaluate before the loop starts.
+This is done using a `progn'.")
+
+
+
+
+;;;; Loop Commands
+;;;;; At Commands
+(defvar loopy--at-instructions nil
+  "These sublists are the instructions that affect a loop higher up the call list.
+
+Mostly, these are variable declarations, as determined by
+`loopy--external-at-targets'.
+
+The form of the instructions that eventually set values in this variable
+are `(loopy--at-instructions (LOOP-NAME INSTRUCTION INSTRUCTION ...))'.
+
+These instructions are removed when that loop expansion is complete.")
+
+(defvar loopy--valid-external-at-targets
+  ;; Iteration vars currently needed for `expr'.
+  ;;
+  ;; TODO: We should probably change what the variables are named
+  '( loopy--iteration-vars
+     loopy--accumulation-vars
+     loopy--accumulation-final-updates
+     loopy--skip-used
+     loopy--non-returning-exit-used
+     loopy--implicit-return)
+  "Valid targets for instructions pushed upwards by the `at' command.
+
+Instructions not in this list are interpreted by the current
+loop.")
+
+;;;;; Loop Body Settings
+(defvar loopy--pre-conditions nil
+  "The list of expressions that determine whether the `while' loop starts/loops.
+These are fed to an `and', so all conditions must be true for the
+  `while' to start/loop.")
+
+(defvar loopy--main-body nil
+  "A list of expressions to run (in order) inside the loop.
+These expressions are created by parsing the loop commands passed to `loopy'.
+
+For example, the command (list i my-list) effectively puts
+\(setq i (pop my-list)) into the loop body.  Most commands require some setup,
+and so don't affect only the loop body.")
+
+(defvar loopy--latter-body nil
+  "A list of expressions to run after the main loop body.
+These expressions are created by parsing the loop commands passed to `loopy'.
+
+For example, updating an indexing variable should only happen
+after the variable is used.")
+
+(defvar loopy--post-conditions nil
+  "Post-conditions that could cause the loop to exit evaluating the loop body.
+
+All expressions in the list must be true for the program to continue.
+This is similar to `do-while' in other languages.")
+
+(defvar loopy--skip-used nil
+  "Whether a skip/continue command is present in the loop main body.")
+
+(defvar loopy--skip-tag-name nil
+  "The symbol used for the `cl-body' tag use by the `skip' command.")
+
+(defvar loopy--non-returning-exit-used nil
+  "Whether a command uses a tag-body to jump to the end of the `cl-block'.
+
+This has the effect of leaving the loop without immediately
+returning a value.")
+
+(defvar loopy--non-returning-exit-tag-name nil
+  "The tag used by the `leave', `while', and `until' commands.")
+
+
+(defvar loopy--accumulations-updated nil
+  "Whether the accumulation variables were finally updated.
+
+If a `cl-tagbody' exit is used (such by a `while' or `until'
+command, which don't return values, just leaving the loop), then
+the `after-do' body is skipped.  This also has the consequence of
+skipping the final update to accumulation variables, which needs
+to run before the `after-do' body so that the variable is safe
+when accessed.
+
+To work around this, the final update before the `after-do' will
+set this variable to t if it has run.  This value will be
+checked after the tag-body exit if `loopy--non-returning-exit-used' is
+t.")
+
+(defvar loopy--after-do nil
+  "Expressions to run (in order) after the loop successfully completes.
+These run in a `progn'.")
+
+(defvar loopy--final-do nil
+  "A list of expressions always run (in order) after the loop finishes/exits.")
+
+(defvar loopy--final-return nil
+  "What the macro finally returns.  This overrides any early return value.")
+
+(defvar loopy--implicit-return nil
+  "The implicit return value of loops that use accumulation commands.
+
+This variable will contain a list of expressions that will be
+returned by the macro if no other value is returned.")
+
+;;;;; Loop Command Variables
+
+(defvar loopy-result nil
+  "The result of using implicit accumulation commands in `loopy'.
+
+All accumulation commands with no given variable (such
+as `(collect my-val)') will accumulate into `loopy-result'.
+
+While `loopy-result' is an implied return value, it need not be
+the only implied value, and can still be returned in a list with
+other implied return values, if any.")
+
+(defvar loopy--generalized-vars nil
+  "A list of symbols and macro expansions explicitly named in loop commands.
+
+To create `setf'-able variables, the symbol needs to be expanded
+to a form that can be treated as such.  In this case, with
+`cl-symbol-macrolet'.")
+
+(defvar loopy--iteration-vars nil
+  "A list of symbols and values to initialize variables for iteration commands.
+
+These initializations are sensitive to order.
+
+This list includes variables explicitly named in a command (such
+as the `i' in `(list i my-list)'), variables required for
+destructuring in iteration commands, and other variables required
+for iteration.")
+
+(defvar loopy--accumulation-vars nil
+  "Initializations of the variables needed for accumulation.
+
+These initializations are sensitive to order.
+
+This list includes variables explicitly named in a command (such
+as the `collection' in `(collect collection value)') and variables
+required for destructuring in accumulation commands.
+
+Unlike in `loopy--iteration-vars', these variables should be
+accessible from anywhere in the macro, and should not be reset
+for sub-loops.")
+
+(defvar loopy--accumulation-list-end-vars nil
+  "Associations of accumulation variables and variables pointing to their ends.
+
+This map has two levels.  The first key is the current loop
+name (as stored in `loopy--loop-name').  The second key is the
+symbol naming the accumulation variable.  The value is a symbol
+naming the end-tracking variable.  Therefore, an entry has the
+form ((LOOP . VAR) . TRACKING-VAR).
+
+Pairs at the top of the list are from the current loop, and are
+removed when the instructions from that loop are done being
+processed.
+
+This variable is treated like a stack.  Alist entries are pushed
+onto this stack while processing the loop, and are popped off
+after the current loop is processed.
+
+When working with lists, it is useful to be able to reference the
+last link in the list.  This makes appending to the end of the
+list much easier.  When using multiple accumulation commands, it
+is important that such commands use the same variable to keep
+track of the end of the list.")
+
+(defvar loopy--accumulation-final-updates nil
+  "Alist of actions to perform on accumulation variables after the loop ends.
+
+This variable's instructions are of the form `(VAR . ACTION)'.
+To avoid accidentally updating a variable multiple times (such as
+reversing a list twice), each VARIABLE can only be updated in a
+single way.")
+
+;;;;; Command Error Checking
+(defvar loopy--accumulation-variable-info nil
+  "Information about accumulation variables to ensure command compatibility.
+
+Information is of the form (VARIABLE-NAME CATEGORY COMMAND).
+Current categories are `list', `string', `vector', `value', and
+`reverse-list'.
+
+This variable is treated like a stack.  Alist entries are pushed
+onto this stack while processing the loop, and are popped off
+after the current loop is processed.
+
+These entries are not instructions.  They are derived from
+`loopy--accumulation-final-updates' while processing instructions
+during macro expansion.  See
+`loopy--check-accumulation-compatibility' for more.")
+
+(defvar loopy--in-sub-level nil
+  "Whether the commands parsed are not in the top level of a loop.
+
+Certain commands (e.g., `list' or `array') can only occur in the
+top level of a loop.  Sub-loops (those created by the `sub-loop'
+command) create for themselves a new, local top level.")
+
+;;;; All variables
+(eval-and-compile
+  (defvar loopy--variables
+    '(loopy--loop-name
+      loopy--with-vars
+      loopy--without-vars
+      loopy--before-do
+      loopy--after-do
+      loopy--final-do
+      loopy--final-return
+
+      ;; -- Vars for processing loop commands --
+      ;; NOTE: `loopy--at-instructions' cannot be local to each loop:
+      ;; loopy--at-instructions
+      loopy--iteration-vars
+      loopy--accumulation-vars
+      loopy--generalized-vars
+      loopy--pre-conditions
+      loopy--main-body
+      loopy--latter-body
+      loopy--post-conditions
+      loopy--implicit-return
+
+      ;; -- Variables for constructing code --
+      loopy--skip-tag-name
+      loopy--skip-used
+      loopy--non-returning-exit-tag-name
+      loopy--non-returning-exit-used
+      loopy--accumulation-final-updates
+      ;; loopy--accumulation-list-end-vars
+      ;; loopy--accumulation-variable-info
+      loopy--in-sub-level
+
+      ;; -- Flag Variables --
+      loopy-iter--lax-naming
+      loopy--destructuring-for-with-vars-function
+      loopy--destructuring-for-iteration-function
+      loopy--destructuring-accumulation-parser
+      loopy--split-implied-accumulation-results)
+    "These variables must be `let'-bound around the loop.
+
+This list is mainly fed to the macro `loopy--wrap-variables-around-body'."))
+
+;;;; Functions to for macro expansion
+
+(defun loopy--bound-p (var-name)
+  "Check if VAR-NAME (a symbol) is already bound for the macro.
+
+This can happen when multiple loop commands refer to the same
+variable, or when a variable is introduced via `with'.
+
+The variable can exist in `loopy--with-vars',
+`loopy--iteration-vars', `loopy--accumulation-vars', or
+`loopy--generalized-vars'."
+  (or (memq var-name (mapcar #'car loopy--with-vars))
+      (memq var-name (mapcar #'car loopy--iteration-vars))
+      (memq var-name (mapcar #'car loopy--accumulation-vars))
+      (memq var-name (mapcar #'car loopy--generalized-vars))
+      (memq var-name loopy--without-vars)))
+
+(defun loopy--already-implicit-return (expression)
+  "Check whether EXPRESSION is in the list of implied return values.
+
+Accumulation commands can operate on the same variable, and we
+  don't want that variable to appear more than once as an implied return."
+  (member expression loopy--implicit-return))
+
+(defun loopy--special-macro-argument-p (symbol arguments-list)
+  "Whether SYMBOL is a special macro argument (including aliases).
+
+Special macro arguments are listed in ARGUMENTS-LIST
+or `loopy-command-aliases'."
+  (memq symbol (append arguments-list
+                       (let ((results))
+                         (dolist (alias loopy-command-aliases)
+                           (when (memq (cdr alias) arguments-list)
+                             (push (car alias) results)))
+                         results))))
+
+(defun loopy--known-loop-name-p (target)
+  "Whether TARGET is a known loop name."
+  (memq target loopy--known-loop-names))
+
+(defun loopy--check-target-loop-name (target)
+  "Signal an error whether TARGET is not a valid loop name."
+  (unless (loopy--known-loop-name-p target)
+    (error "Unknown loop target: %s" target)))
+
+(defmacro loopy--wrap-variables-around-body (&rest body)
+  "Wrap variables in `loopy--variables' in `let*' bindings around BODY."
+  (macroexp-let* (mapcar (lambda (x) (list x nil))
+                         loopy--variables)
+                 (macroexp-progn body)))
+
+(defun loopy--find-all-names (name-or-names)
+  "Search for aliases in `loopy-command-aliases'.  Return all names.
+
+NAME-OR-NAMES is a symbol or list of built-in aliases.
+
+The returned value includes the original arguments."
+  (when (symbolp name-or-names)
+    (setf name-or-names (list name-or-names)))
+  `(,@name-or-names
+    ,@(mapcar #'car (map-filter (lambda (_ val) (memq val name-or-names))
+                                loopy-command-aliases))))
+
+(defun loopy--apply-flag (flag)
+  "Apply the effects of the FLAG."
+  (if-let ((func (map-elt loopy--flag-settings flag)))
+      (funcall func)
+    (error "Loopy: Flag not defined: %s" flag)))
+
+(defun loopy--valid-external-at-target-p (target)
+  "Check if variable TARGET is valid for an `at' command.
+
+This predicate checks for presence in the list
+`loopy--valid-external-at-targets'."
+  (memq target loopy--valid-external-at-targets))
+
+
+(provide 'loopy-vars)
+;;; loopy-vars.el ends here


### PR DESCRIPTION
Fixes #70.


- Changes:
  - add `at` command
  - Change `sub-loop` command to be a full `loopy` loop in `loopy`, or `loopy-iter` in `loopy-iter`. Accumulation in sub-loops now require the `at` command to returned in super-loops.
  - Add `loopy-lambda`
  - Add `leave-from` and `skip-from`

