### PR TITLE
Convert uses of `cl-tagbody` to `catch` and `throw`.

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -3613,22 +3613,20 @@ sorting requirements on the accumulations variables.
             (let* ,loopy--iteration-vars
               (let ((loopy--early-return-capture
                      (cl-block ,loopy--loop-name
-                       (cl-tagbody
-                        ,@loopy--before-do
-                        (while ,(cl-case (length loopy--pre-conditions)
-                                  (0 t)
-                                  (1 (car loopy--pre-conditions))
-                                  (t (cons 'and loopy--pre-conditions)))
-                          (cl-tagbody
-                           ,@loopy--main-body
-                           loopy--continue-tag
+                       ,@loopy--before-do
+                       (catch loopy--non-returning-exit-tag-name
+                         (while ,(cl-case (length loopy--pre-conditions)
+                                   (0 t)
+                                   (1 (car loopy--pre-conditions))
+                                   (t (cons 'and loopy--pre-conditions)))
+                           (catch loopy--skip-tag-name
+                             ,@loopy--main-body)
                            ,@loopy--latter-body
                            (unless ,loopy--post-conditions
                              (cl-return-from ,loopy--loop-name
-                               ,loopy--implicit-return))))
-                        ,@loopy--after-do
-                        loopy--non-returning-exit-tag
-                        ,loopy--accumulation-final-updates))
+                               ,loopy--implicit-return)))
+                         ,loopy--accumulation-final-updates
+                         ,@loopy--after-do))
                      ,loopy--implicit-return))
                 ,@loopy--final-do
                 ,(if loopy--final-return

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -573,7 +573,7 @@ attempting to do something like the below example might not do what you
 expect, as @samp{i} is assigned a value from the list after collecting @samp{i} into
 @samp{coll}.
 
-@float Listing,orge27adc9
+@float Listing,org8856d49
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -3919,22 +3919,20 @@ will work similar to the below example.
        (let* ,loopy--iteration-vars
          (let ((loopy--early-return-capture
                 (cl-block ,loopy--loop-name
-                  (cl-tagbody
-                   ,@@loopy--before-do
-                   (while ,(cl-case (length loopy--pre-conditions)
-                             (0 t)
-                             (1 (car loopy--pre-conditions))
-                             (t (cons 'and loopy--pre-conditions)))
-                     (cl-tagbody
-                      ,@@loopy--main-body
-                      loopy--continue-tag
+                  ,@@loopy--before-do
+                  (catch loopy--non-returning-exit-tag-name
+                    (while ,(cl-case (length loopy--pre-conditions)
+                              (0 t)
+                              (1 (car loopy--pre-conditions))
+                              (t (cons 'and loopy--pre-conditions)))
+                      (catch loopy--skip-tag-name
+                        ,@@loopy--main-body)
                       ,@@loopy--latter-body
                       (unless ,loopy--post-conditions
                         (cl-return-from ,loopy--loop-name
-                          ,loopy--implicit-return))))
-                   ,@@loopy--after-do
-                   loopy--non-returning-exit-tag
-                   ,loopy--accumulation-final-updates))
+                          ,loopy--implicit-return)))
+                    ,loopy--accumulation-final-updates
+                    ,@@loopy--after-do))
                 ,loopy--implicit-return))
            ,@@loopy--final-do
            ,(if loopy--final-return

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -2119,7 +2119,7 @@ This function is called by `loopy--get-optimized-accum'."
                 (loopy--accumulation-vars (,var nil))
                 (loopy--main-body (when ,test-form
                                     (setq ,var ,val)
-                                    (go ,tag-name)))
+                                    (throw (quote ,tag-name) t)))
                 ;; If VAR nil, bind to ON-FAILURE.
                 ,(when on-failure
                    `(loopy--accumulation-final-updates
@@ -2135,7 +2135,7 @@ This function is called by `loopy--get-optimized-accum'."
                 (loopy--accumulation-vars (,var nil))
                 (loopy--main-body (when ,test-form
                                     (setq ,var ,val)
-                                    (go ,tag-name)))
+                                    (throw (quote ,tag-name) t)))
                 ;; If VAR nil, bind to ON-FAILURE.
                 ,(when on-failure
                    `(loopy--accumulation-final-updates
@@ -2617,7 +2617,7 @@ returned."
   "Parse the `leave' command."
   (let ((tag-name (loopy--produce-non-returning-exit-tag-name loopy--loop-name)))
     `((loopy--non-returning-exit-used ,tag-name)
-      (loopy--main-body (go ,tag-name)))))
+      (loopy--main-body (throw (quote ,tag-name) t)))))
 
 (cl-defun loopy--parse-leave-from-command ((_ target-loop))
   "Parse the `leave-from' command."
@@ -2625,7 +2625,7 @@ returned."
   (let ((tag-name (loopy--produce-non-returning-exit-tag-name target-loop)))
     `((loopy--at-instructions (,target-loop
                                (loopy--non-returning-exit-used ,tag-name)))
-      (loopy--main-body (go ,tag-name)))))
+      (loopy--main-body (throw (quote ,tag-name) t)))))
 
 ;;;;;; Return
 (cl-defun loopy--parse-return-command ((_ &rest values))
@@ -2652,7 +2652,7 @@ returned."
   "Parse the `skip' loop command."
   (let ((tag-name (loopy--produce-skip-tag-name loopy--loop-name)))
     `((loopy--skip-used ,tag-name)
-      (loopy--main-body (go ,tag-name)))))
+      (loopy--main-body (throw (quote ,tag-name) t)))))
 
 (cl-defun loopy--parse-skip-from-command ((_ target-loop))
   "Parse the `skip-from' loop command as (skip-from LOOP-NAME)."
@@ -2660,7 +2660,7 @@ returned."
   (let ((tag-name (loopy--produce-skip-tag-name target-loop)))
     `((loopy--at-instructions (,target-loop
                                (loopy--skip-used ,tag-name)))
-      (loopy--main-body (go ,tag-name)))))
+      (loopy--main-body (throw (quote ,tag-name) t)))))
 
 ;;;;;; While Until
 (cl-defun loopy--parse-while-until-commands ((name condition &rest conditions))
@@ -2675,8 +2675,8 @@ CONDITIONS is the remaining optional conditions."
     `((loopy--non-returning-exit-used ,tag-name)
       (loopy--main-body (if ,condition
                             ,@(cl-ecase name
-                                (until `((go ,tag-name)))
-                                (while `(nil (go ,tag-name)))))))))
+                                (until `((throw (quote ,tag-name) t)))
+                                (while `(nil (throw (quote ,tag-name) t)))))))))
 
 ;;;; Destructuring
 


### PR DESCRIPTION
This is a better fix for #88.