### PR TITLE
Separate built-in aliases from preferred names.

### DIFF
--- a/.github/workflows/emacs-27-tests.yml
+++ b/.github/workflows/emacs-27-tests.yml
@@ -29,6 +29,10 @@ jobs:
         run: sudo apt-get install emacs27
       - name: Check Emacs 27 version  
         run: emacs27 --version
+      - name: Create the folder
+        run: mkdir dependecy-links
+      - name: Download Map
+        run: wget --output-document="dependecy-links/map.el" "https://git.savannah.gnu.org/cgit/emacs.git/plain/lisp/emacs-lisp/map.el"
       - name: Basic tests
         run: emacs27 -batch -l ert -l tests/tests.el -f ert-run-tests-batch-and-exit
       - name: Seq tests
@@ -38,8 +42,6 @@ jobs:
       - name: Iter tests
         run: emacs27 -batch -l ert -l tests/iter-tests.el -f ert-run-tests-batch-and-exit
       - run: echo "Now doing Dash tests."
-      - name: Create the folder
-        run: mkdir dependecy-links
       - name: Download Dash
         run: wget --output-document="dependecy-links/dash.el" "https://raw.githubusercontent.com/magnars/dash.el/master/dash.el"
       - name: Dash tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,21 @@ This document describes the user-facing changes to Loopy.
 - The `map`command now filters out duplicate keys by default.  `map-ref` already 
   did this. The behavior is now optional in both commands using the `unique` 
   keyword argument.
+- __The way to add aliases has changed.__ ([#100], [#105])
+  - `loopy-command-aliases` was renamed to `loopy-aliases`.  The old name is
+    obsolete.
+  - The structure of `loopy-aliases` changed.  For forward compatibility,
+    aliases should only be defined using `loopy-defalias`.
+  - Recursive definitions are now resolved at definition.  This avoids needing
+    to slowly search for many names for each expression passed to the macro,
+    which was doubling the expansion time and complicating code.
+- Add `loopy-iter-ignored-names`, which replaces `loopy-iter-ignored-commands`
+  ([#100], [#105]).  This new variable also includes the aliases of special
+  macro arguments, such as `let*` for `with`.  The name of the old variable is
+  now an obsolete alias of the new variable, though note that the use is now
+  more general.
+- The variable names `loopy-custom-command-aliases` and
+  `loopy-custom-command-parsers` are now obsolete.
 
 ### Other Changes
 
@@ -43,9 +58,11 @@ This document describes the user-facing changes to Loopy.
   *repeats* the loop zero times.
 
 [#89]: https://github.com/okamsn/loopy/issues/89
+[#96]: https://github.com/okamsn/loopy/pull/96
+[#100]: https://github.com/okamsn/loopy/issues/100
 [#101]: https://github.com/okamsn/loopy/issues/101
 [#102]: https://github.com/okamsn/loopy/pull/102
-[#96]: https://github.com/okamsn/loopy/pull/96
+[#105]: https://github.com/okamsn/loopy/pull/105
 
 ## 0.9.1
 

--- a/README.org
+++ b/README.org
@@ -38,6 +38,11 @@ please let me know.
    - The =map= command now filters out duplicate keys by default.  =map-ref=
      already did this.  The behavior is now optional in both commands using the
      =unique= keyword argument.
+   - Aliases now work differently.  The gist is that they should now only be
+     defined with ~loopy-defalias~ (for forward compatibility) and that
+     recursive definitions are now resolved at definition time instead of when
+     expanding the macro.  See the change log and updated Org/Info documentation
+     for more.
  - Version 0.9.1 (2021-09-06):
    - Accumulation variables can no longer be modified outside of accumulation
      commands.  The speed penalty was too great and discouraged destructuring

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -540,8 +540,8 @@ libraries =seq= ([[info:elisp#Sequence Functions]]) and =cl-lib= ([[info:cl]])).
   For convenience and understanding, the same command might have multiple names,
   called {{{dfn(aliases)}}}.  For example, the command =expr= has an alias
   =set=, because =expr= is used to /set/ a variable to the value of an
-  /expression/.  You can add custom aliases using the function ~loopy-defalias~,
-  which modifies the user option ~loopy-command-aliases~ ([[#custom-aliases][Custom Aliases]]).
+  /expression/.  You can define custom aliases using the macro ~loopy-defalias~
+  ([[#custom-aliases][Custom Aliases]]).
 
   Some commands take optional keyword arguments.  For example, the command
   =list= can take a function argument following the keyword =:by=, which affects
@@ -2996,153 +2996,158 @@ remove the sorting requirements on the accumulations variables.
 
   
 * The ~loopy-iter~ Macro
-  :PROPERTIES:
-  :CUSTOM_ID: loopy-iter
-  :DESCRIPTION: Embedding loop commands in arbitrary code.
-  :END:
+:PROPERTIES:
+:CUSTOM_ID: loopy-iter
+:DESCRIPTION: Embedding loop commands in arbitrary code.
+:END:
 
-  #+cindex: loopy-iter
-  #+findex: loopy-iter
-  ~loopy-iter~ is a macro that allows for the embedding of loop commands inside
-  arbitrary code.  This is different from the =do= loop command, with which one
-  can embed arbitrary code in a loop.  You must use ~require~ to load this
-  feature.
+#+cindex: loopy-iter
+#+findex: loopy-iter
+~loopy-iter~ is a macro that allows for the embedding of loop commands inside
+arbitrary code.  This is different from the =do= loop command, with which one
+can embed arbitrary code in a loop.  You must use ~require~ to load this
+feature.
 
-  #+attr_texinfo: :tag Warning
-  #+begin_quote
-  *This feature is still experimental.*  It might not work correctly in all
-  circumstances.  Please report any problems you come across on this project's
-  [[https://github.com/okamsn/loopy/issues][issues tracker]].
-  #+end_quote
+#+attr_texinfo: :tag Warning
+#+begin_quote
+*This feature is still experimental.*  It might not work correctly in all
+circumstances.  Please report any problems you come across on this project's
+[[https://github.com/okamsn/loopy/issues][issues tracker]].
+#+end_quote
 
-  This macro is meant to be conceptually similar to the ~iterate~ or ~iter~
-  macro provided by the Common Lisp package "Iterate" [fn:iter] (not to be
-  confused with the ~iter-*~ functions provided by Emacs).
+This macro is meant to be conceptually similar to the ~iterate~ or ~iter~
+macro provided by the Common Lisp package "Iterate" [fn:iter] (not to be
+confused with the ~iter-*~ functions provided by Emacs).
 
-  #+begin_src emacs-lisp
-    (require 'loopy-iter) ; <- Must `require' to load feature.
+#+begin_src emacs-lisp
+  (require 'loopy-iter) ; <- Must `require' to load feature.
 
-    ;; => (2 4 6)
-    (loopy-iter (for list i '(1 2 3))
-                (let ((a (* 2 i)))
-                  (accum collect a)))
-  #+end_src
+  ;; => (2 4 6)
+  (loopy-iter (for list i '(1 2 3))
+              (let ((a (* 2 i)))
+                (accum collect a)))
+#+end_src
 
-  #+cindex: loopy-iter keywords
-  #+vindex: loopy-iter-command-keywords
-  To clearly distinguish between loop commands and Emacs features (such as
-  between the loop command =list= and the function ~list~), a loop command must
-  be preceded by one of the keywords listed in ~loopy-iter-command-keywords~.
-  By default, this is one of =for=, =accum=, or =exit=.  These keywords do not
-  share a name with any built-in Emacs feature and are similar to the keywords
-  used by other packages.  For example, =(list VAR LIST)= would be =(for list
-  VAR LIST)= or =(for in VAR LIST)=.
+#+cindex: loopy-iter keywords
+#+vindex: loopy-iter-command-keywords
+To clearly distinguish between loop commands and Emacs features (such as
+between the loop command =list= and the function ~list~), a loop command must
+be preceded by one of the keywords listed in ~loopy-iter-command-keywords~.
+By default, this is one of =for=, =accum=, or =exit=.  These keywords do not
+share a name with any built-in Emacs feature and are similar to the keywords
+used by other packages.  For example, =(list VAR LIST)= would be =(for list
+VAR LIST)= or =(for in VAR LIST)=.
 
-  Any keyword in the user option ~loopy-iter-command-keywords~ can be used to
-  identify any loop command.  For example, =(accum collect a)= and
-  =(for collect a)= are both valid ways of referring to the =collect= loop
-  command in ~loopy-iter~.
+Any keyword in the user option ~loopy-iter-command-keywords~ can be used to
+identify any loop command.  For example, =(accum collect a)= and
+=(for collect a)= are both valid ways of referring to the =collect= loop
+command in ~loopy-iter~.
 
-  To disable this requirement, use the flag =lax-naming= ([[#flags][Using Flags]]).  When
-  using =lax-naming=, ~loopy-iter~ will always prefer built-in features to loop
-  commands.  For example, "list" will always be understood as referring to the
-  function ~list~ and not the loop command =list=.
+To disable this requirement, use the flag =lax-naming= ([[#flags][Using Flags]]).  When
+using =lax-naming=, ~loopy-iter~ will always prefer built-in features to loop
+commands.  For example, "list" will always be understood as referring to the
+function ~list~ and not the loop command =list=.
 
-  #+vindex: loopy-iter-ignored-commands
-  If for some reason you wish for ~loopy-iter~ to ignore a loop command while
-  using =lax-naming=, you can add that symbol to ~loopy-iter-ignored-commands~.
+Special macro arguments, already having clearly distinguishable names, do not
+need to be preceded by one of the above keywords.
 
-  Special macro arguments, already having clearly distinguishable names, do not
-  need to be preceded by one of the above keywords.  However, some aliases (such
-  as =let*= for =with=) have been disabled.
+#+cindex: Ignoring names in loopy-iter
+#+vindex: loopy-iter-ignored-names
+That being said, the names of some ~loopy~ features /can/ cause conflicts, such
+as the alias =let*= for the special macro argument =with=.  To ignore these
+names, list them in the user option ~loopy-iter-ignored-names~.  The symbol
+=let*= is included by default.
 
-  #+begin_src emacs-lisp
-    ;; => ((1 8) (2 9) (3 10))
-    (loopy-iter (with (a 7))                ; <- Set once around loop.
-                (for list elem '(1 2 3))
-                (let* ((c elem)             ; <- These set inside of loop.
-                       (d (+ a c)))
-                  (accum collect (list c d))))
-  #+end_src
+This user option always applies to special macro arguments.  It only applies to
+loop commands when =lax-naming= is enabled.
 
-  Restrictions on the placement of loop commands and special macro arguments
-  still apply in ~loopy-iter~.  For example, iteration commands must still occur
-  at the top level of ~loopy-iter~ or a sub-loop.
+#+begin_src emacs-lisp
+  ;; => ((1 8) (2 9) (3 10))
+  (loopy-iter (with (a 7))                ; <- Set once around loop.
+              (for list elem '(1 2 3))
+              (let* ((c elem)             ; <- These set inside of loop.
+                     (d (+ a c)))
+                (accum collect (list c d))))
+#+end_src
 
-  #+begin_src emacs-lisp
-    ;; BAD
-    (loopy-iter (let ((a (progn
-                           ;; ERROR: `list' must occur at top level.
-                           (for list j '(8 9 10 11 12))
-                           j)))
-                  (accum collect a)))
+Restrictions on the placement of loop commands and special macro arguments
+still apply in ~loopy-iter~.  For example, iteration commands must still occur
+at the top level of ~loopy-iter~ or a sub-loop.
 
-    ;; GOOD
-    ;; => (8 9 10 11 12)
-    (loopy-iter (let ((a (progn
-                           ;; NOTE: No restriction on placement of `expr'.
-                           (for expr j 8 (1+ j))
-                           ;; Leave loop but don't force return value,
-                           ;; allowing the implicit result to be returned.
-                           (exit until (> j 12))
-                           j)))
-                  (accum collect a)))
-  #+end_src
+#+begin_src emacs-lisp
+  ;; BAD
+  (loopy-iter (let ((a (progn
+                         ;; ERROR: `list' must occur at top level.
+                         (for list j '(8 9 10 11 12))
+                         j)))
+                (accum collect a)))
 
-  #+attr_texinfo: :tag Caution
-  #+begin_quote
-  You should not reply on the value of a loop command's expanded code.  Such
-  expanded code is an implementation detail and subject to change.
-  #+end_quote
+  ;; GOOD
+  ;; => (8 9 10 11 12)
+  (loopy-iter (let ((a (progn
+                         ;; NOTE: No restriction on placement of `expr'.
+                         (for expr j 8 (1+ j))
+                         ;; Leave loop but don't force return value,
+                         ;; allowing the implicit result to be returned.
+                         (exit until (> j 12))
+                         j)))
+                (accum collect a)))
+#+end_src
 
-  For convenience, ~loopy-iter~ will not attempt to interpret loop commands in
-  quoted code, except in sharp-quoted ~lambda~ forms.  This is because the
-  ~lambda~ macro is self-quoting, and so Emacs might quote the form before it is
-  seen by ~loopy-iter~.
+#+attr_texinfo: :tag Caution
+#+begin_quote
+You should not reply on the value of a loop command's expanded code.  Such
+expanded code is an implementation detail and subject to change.
+#+end_quote
 
-  #+begin_src emacs-lisp
-    ;; => (1 2 3)
-    (loopy-iter (for list elem '(1 2 3))
-                (funcall (lambda (x)
+For convenience, ~loopy-iter~ will not attempt to interpret loop commands in
+quoted code, except in sharp-quoted ~lambda~ forms.  This is because the
+~lambda~ macro is self-quoting, and so Emacs might quote the form before it is
+seen by ~loopy-iter~.
+
+#+begin_src emacs-lisp
+  ;; => (1 2 3)
+  (loopy-iter (for list elem '(1 2 3))
+              (funcall (lambda (x)
+                         (accum collect x))
+                       elem))
+
+  ;; => (1 2 3)
+  (loopy-iter (for list elem '(1 2 3))
+              (funcall #'(lambda (x) ; <- sharp-quoted, but still interpreted
                            (accum collect x))
-                         elem))
+                       elem))
+#+end_src
 
-    ;; => (1 2 3)
-    (loopy-iter (for list elem '(1 2 3))
-                (funcall #'(lambda (x) ; <- sharp-quoted, but still interpreted
-                             (accum collect x))
-                         elem))
-  #+end_src
+In ~loopy~, the =sub-loop= command is a full ~loopy~ loop ([[#sub-loops]]).  In
+~loopy-iter~, it is a full ~loopy-iter~ loop.
 
-  In ~loopy~, the =sub-loop= command is a full ~loopy~ loop ([[#sub-loops]]).  In
-  ~loopy-iter~, it is a full ~loopy-iter~ loop.
+#+begin_src emacs-lisp
+  ;; => (2 3 4 5)
+  (loopy-iter outer
+              (for list i '([1 2] [3 4]))
+              (for loop
+                   ;; NOTE: `loopy-iter' style, not `loopy' style
+                   (for array j i)
+                   (for at outer
+                        (let ((val (1+ j)))
+                          (accum collect val)))))
+#+end_src
 
-  #+begin_src emacs-lisp
-    ;; => (2 3 4 5)
-    (loopy-iter outer
-                (for list i '([1 2] [3 4]))
-                (for loop
-                     ;; NOTE: `loopy-iter' style, not `loopy' style
-                     (for array j i)
-                     (for at outer
-                          (let ((val (1+ j)))
-                            (accum collect val)))))
-  #+end_src
+If you do not want this, you can specifically use a full ~loopy~ loop using
+the loop command ~loopy~ instead, as in =(for loopy)=.
 
-  If you do not want this, you can specifically use a full ~loopy~ loop using
-  the loop command ~loopy~ instead, as in =(for loopy)=.
+#+attr_texinfo: :tag Note
+#+begin_quote
+Nesting arbitrary code in the loop requires knowing how to understand the
+code.  You might find cases where ~loopy-iter~ interprets code incorrectly.
 
-  #+attr_texinfo: :tag Note
-  #+begin_quote
-  Nesting arbitrary code in the loop requires knowing how to understand the
-  code.  You might find cases where ~loopy-iter~ interprets code incorrectly.
+Please report such cases on this project's [[https://github.com/okamsn/loopy/issues][issues tracker]].
+#+end_quote
 
-  Please report such cases on this project's [[https://github.com/okamsn/loopy/issues][issues tracker]].
-  #+end_quote
-
-  ~loopy~ (and so ~loopy-iter~) does not currently have all of the features of
-  Common Lisp's ~iter~ macro.  Think of it more as an alternative form of
-  ~loopy~ instead of a port of ~iter~.
+~loopy~ (and so ~loopy-iter~) does not currently have all of the features of
+Common Lisp's ~iter~ macro.  Think of it more as an alternative form of
+~loopy~ instead of a port of ~iter~.
 
 
 * Using Flags
@@ -3300,54 +3305,107 @@ remove the sorting requirements on the accumulations variables.
 
 
 * Custom Aliases
-  :PROPERTIES:
-  :CUSTOM_ID: custom-aliases
-  :DESCRIPTION: How to add one's own aliases.
-  :END:
+:PROPERTIES:
+:CUSTOM_ID: custom-aliases
+:DESCRIPTION: How to add one's own aliases.
+:END:
 
-  #+cindex: custom aliases
-  An {{{dfn(alias)}}} is another name for a command.  ~loopy~ comes with several
-  built-in aliases, such as =set= for the command =expr=.
+#+cindex: custom aliases
+An {{{dfn(alias)}}} is another name for a command or special macro argument.
+~loopy~ comes with several built-in aliases, such as =string= for the command
+=array= or =else= for the special macro argument =after-do=.
 
-  #+vindex: loopy-command-aliases
-  #+findex: loopy-defalias
-  Custom aliases can be added to the user option ~loopy-command-aliases~, which
-  associates aliases with their true names.  For convenience, the macro
-  ~loopy-defalias~ is provided, which will correctly add an association to
-  this variable.
+| Command or Special Macro Argument | Built-In Aliases           |
+|-----------------------------------+----------------------------|
+| =array=                           | =string=                   |
+| =seq-ref=                         | =sequence-ref=, =seqf=     |
+| =after-do=                        | =after=, =else=, =else-do= |
 
-  #+begin_src emacs-lisp
-    ;; You don't need to quote either argument,
-    ;; but you can if you prefer.
-    (loopy-defalias l list)
-    (loopy-defalias a 'array)
 
-    ;; => ((1 . 4) (2 . 5) (3 . 6))
-    (loopy (l i '(1 2 3))
-           (a j [4 5 6])
-           (collect (cons i j)))
+An alias works the same as the original command or special macro argument.
+They are provided for clarity and convenience.
 
-    ;; => ((a . array) (l . list))
-    loopy-command-aliases
-  #+end_src
+#+begin_src emacs-lisp
+  ;; => ("a" "b" "c" "d")
+  (loopy (array i "abcd")
+         (collect (char-to-string i)))
 
-  When looking for a command parser, =loopy= will always check whether a given
-  name is an alias before checking whether it is a command.  Additionally,
-  aliases can be recursive.  That is, you can create a new alias for an existing
-  alias.
+  ;; => ("a" "b" "c" "d")
+  (loopy (string i "abcd")
+         (collect (char-to-string i)))
+#+end_src
 
-  Special macro arguments ([[#macro-arguments][Special Macro Arguments]]) can also be aliased.  Using
-  an alias does not change the fact that the special macro arguments are parsed
-  before loop commands.
 
-  #+begin_src emacs-lisp
-    (loopy-defalias as with)
+#+findex: loopy-defalias
+Users can define custom aliases using the macro ~loopy-defalias~, which takes an
+alias and a definition as arguments.  These arguments can be quoted or
+unquoted.
 
-    ;; => (8 9 10)
-    (loopy (as (a 7))
-           (list i '(1 2 3))
-           (collect (+ i 7)))
-  #+end_src
+#+begin_src emacs-lisp
+  (loopy-defalias items array)
+
+  ;; => (1 2 3)
+  (loopy (items i [1 2 3])
+         (collect i))
+#+end_src
+
+The definition must exist for the alias to be defined correctly.  Definitions
+can themselves be aliases, so long as they are already defined.  In other words,
+when aliasing custom commands, you should define the alias /after/ defining the
+command ([[#adding-custom-commands]]).
+
+#+begin_src emacs-lisp
+  ;; Define an alias for the `items' alias from above:
+  (loopy-defalias items2 items)
+
+  ;; => (1 2 3)
+  (loopy (items2 i [1 2 3])
+         (collect i))
+#+end_src
+
+When looking for how to parse a command, ~loopy~ will check aliases before
+checking the true names of commands.  Effectively, this means that commands can
+be overridden by aliases, though this is discouraged.  Such commands can still
+be accessed via their other names.
+
+#+begin_src emacs-lisp
+  ;; Define `cons' as an alias of `array':
+  (loopy-defalias cons array)
+
+  ;; => (1 2 3)
+  (loopy (cons i [1 2 3])
+         (collect i))
+
+  ;; ERROR: Can no longer use the original definition:
+  (loopy (cons i '(1 2 3))
+         (collect i))
+
+  ;; Other names still work:
+  ;; => ((1 2 3) (2 3) (3))
+  (loopy (conses i '(1 2 3))
+         (collect i))
+#+end_src
+
+
+Special macro arguments ([[#macro-arguments][Special Macro Arguments]]) can also be aliased.  Using
+an alias does not change the fact that the special macro arguments are parsed
+before loop commands.
+
+#+begin_src emacs-lisp
+  (loopy-defalias as with)
+
+  ;; => (8 9 10)
+  (loopy (as (a 7))
+         (list i '(1 2 3))
+         (collect (+ i 7)))
+#+end_src
+
+
+#+vindex: loopy-aliases
+The macro ~loopy-defalias~ modifies the user option ~loopy-aliases~.  However,
+while ~loopy~ is still changing, it is recommended to avoid modifying this
+variable directly, as its structure may change in the future.  ~loopy-defalias~
+is the forward-compatible way of creating aliases.
 
 
 * Custom Commands
@@ -3413,7 +3471,7 @@ remove the sorting requirements on the accumulations variables.
    Commands are parsed by ~loopy--parse-loop-command~, which receives a command
    call, such as =(list i '(1 2 3))=, and returns a list of instructions.  It
    does this by searching for an appropriate command-specific parsing function
-   in ~loopy-command-aliases~ and ultimately in ~loopy-command-parsers~.  For
+   in ~loopy-aliases~ and ultimately in ~loopy-command-parsers~.  For
    parsing multiple commands in order, there is ~loopy--parse-loop-commands~,
    which wraps the single-command version.
 

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -573,7 +573,7 @@ attempting to do something like the below example might not do what you
 expect, as @samp{i} is assigned a value from the list after collecting @samp{i} into
 @samp{coll}.
 
-@float Listing,orgd3b62fa
+@float Listing,orgf681273
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -586,8 +586,8 @@ expect, as @samp{i} is assigned a value from the list after collecting @samp{i} 
 For convenience and understanding, the same command might have multiple names,
 called @dfn{aliases}.  For example, the command @samp{expr} has an alias
 @samp{set}, because @samp{expr} is used to @emph{set} a variable to the value of an
-@emph{expression}.  You can add custom aliases using the function @code{loopy-defalias},
-which modifies the user option @code{loopy-command-aliases} (@ref{Custom Aliases}).
+@emph{expression}.  You can define custom aliases using the macro @code{loopy-defalias}
+(@ref{Custom Aliases}).
 
 Some commands take optional keyword arguments.  For example, the command
 @samp{list} can take a function argument following the keyword @samp{:by}, which affects
@@ -3271,7 +3271,7 @@ be preceded by one of the keywords listed in @code{loopy-iter-command-keywords}.
 By default, this is one of @samp{for}, @samp{accum}, or @samp{exit}.  These keywords do not
 share a name with any built-in Emacs feature and are similar to the keywords
 used by other packages.  For example, @samp{(list VAR LIST)} would be @samp{(for list
-  VAR LIST)} or @samp{(for in VAR LIST)}.
+VAR LIST)} or @samp{(for in VAR LIST)}.
 
 Any keyword in the user option @code{loopy-iter-command-keywords} can be used to
 identify any loop command.  For example, @samp{(accum collect a)} and
@@ -3283,13 +3283,18 @@ using @samp{lax-naming}, @code{loopy-iter} will always prefer built-in features 
 commands.  For example, ``list'' will always be understood as referring to the
 function @code{list} and not the loop command @samp{list}.
 
-@vindex loopy-iter-ignored-commands
-If for some reason you wish for @code{loopy-iter} to ignore a loop command while
-using @samp{lax-naming}, you can add that symbol to @code{loopy-iter-ignored-commands}.
-
 Special macro arguments, already having clearly distinguishable names, do not
-need to be preceded by one of the above keywords.  However, some aliases (such
-as @samp{let*} for @samp{with}) have been disabled.
+need to be preceded by one of the above keywords.
+
+@cindex Ignoring names in loopy-iter
+@vindex loopy-iter-ignored-names
+That being said, the names of some @code{loopy} features @emph{can} cause conflicts, such
+as the alias @samp{let*} for the special macro argument @samp{with}.  To ignore these
+names, list them in the user option @code{loopy-iter-ignored-names}.  The symbol
+@samp{let*} is included by default.
+
+This user option always applies to special macro arguments.  It only applies to
+loop commands when @samp{lax-naming} is enabled.
 
 @lisp
 ;; => ((1 8) (2 9) (3 10))
@@ -3556,35 +3561,86 @@ Below is an example of the @samp{split} flag.
 @chapter Custom Aliases
 
 @cindex custom aliases
-An @dfn{alias} is another name for a command.  @code{loopy} comes with several
-built-in aliases, such as @samp{set} for the command @samp{expr}.
+An @dfn{alias} is another name for a command or special macro argument.
+@code{loopy} comes with several built-in aliases, such as @samp{string} for the command
+@samp{array} or @samp{else} for the special macro argument @samp{after-do}.
 
-@vindex loopy-command-aliases
-@findex loopy-defalias
-Custom aliases can be added to the user option @code{loopy-command-aliases}, which
-associates aliases with their true names.  For convenience, the macro
-@code{loopy-defalias} is provided, which will correctly add an association to
-this variable.
+@multitable {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaa}
+@headitem Command or Special Macro Argument
+@tab Built-In Aliases
+@item @samp{array}
+@tab @samp{string}
+@item @samp{seq-ref}
+@tab @samp{sequence-ref}, @samp{seqf}
+@item @samp{after-do}
+@tab @samp{after}, @samp{else}, @samp{else-do}
+@end multitable
+
+
+An alias works the same as the original command or special macro argument.
+They are provided for clarity and convenience.
 
 @lisp
-;; You don't need to quote either argument,
-;; but you can if you prefer.
-(loopy-defalias l list)
-(loopy-defalias a 'array)
+;; => ("a" "b" "c" "d")
+(loopy (array i "abcd")
+       (collect (char-to-string i)))
 
-;; => ((1 . 4) (2 . 5) (3 . 6))
-(loopy (l i '(1 2 3))
-       (a j [4 5 6])
-       (collect (cons i j)))
-
-;; => ((a . array) (l . list))
-loopy-command-aliases
+;; => ("a" "b" "c" "d")
+(loopy (string i "abcd")
+       (collect (char-to-string i)))
 @end lisp
 
-When looking for a command parser, @samp{loopy} will always check whether a given
-name is an alias before checking whether it is a command.  Additionally,
-aliases can be recursive.  That is, you can create a new alias for an existing
-alias.
+
+@findex loopy-defalias
+Users can define custom aliases using the macro @code{loopy-defalias}, which takes an
+alias and a definition as arguments.  These arguments can be quoted or
+unquoted.
+
+@lisp
+(loopy-defalias items array)
+
+;; => (1 2 3)
+(loopy (items i [1 2 3])
+       (collect i))
+@end lisp
+
+The definition must exist for the alias to be defined correctly.  Definitions
+can themselves be aliases, so long as they are already defined.  In other words,
+when aliasing custom commands, you should define the alias @emph{after} defining the
+command (@ref{Custom Commands}).
+
+@lisp
+;; Define an alias for the `items' alias from above:
+(loopy-defalias items2 items)
+
+;; => (1 2 3)
+(loopy (items2 i [1 2 3])
+       (collect i))
+@end lisp
+
+When looking for how to parse a command, @code{loopy} will check aliases before
+checking the true names of commands.  Effectively, this means that commands can
+be overridden by aliases, though this is discouraged.  Such commands can still
+be accessed via their other names.
+
+@lisp
+;; Define `cons' as an alias of `array':
+(loopy-defalias cons array)
+
+;; => (1 2 3)
+(loopy (cons i [1 2 3])
+       (collect i))
+
+;; ERROR: Can no longer use the original definition:
+(loopy (cons i '(1 2 3))
+       (collect i))
+
+;; Other names still work:
+;; => ((1 2 3) (2 3) (3))
+(loopy (conses i '(1 2 3))
+       (collect i))
+@end lisp
+
 
 Special macro arguments (@ref{Special Macro Arguments}) can also be aliased.  Using
 an alias does not change the fact that the special macro arguments are parsed
@@ -3598,6 +3654,13 @@ before loop commands.
        (list i '(1 2 3))
        (collect (+ i 7)))
 @end lisp
+
+
+@vindex loopy-aliases
+The macro @code{loopy-defalias} modifies the user option @code{loopy-aliases}.  However,
+while @code{loopy} is still changing, it is recommended to avoid modifying this
+variable directly, as its structure may change in the future.  @code{loopy-defalias}
+is the forward-compatible way of creating aliases.
 
 @node Custom Commands
 @chapter Custom Commands
@@ -3677,7 +3740,7 @@ binding for the variable @samp{list-211} into a @code{let}-like form.
 Commands are parsed by @code{loopy--parse-loop-command}, which receives a command
 call, such as @samp{(list i '(1 2 3))}, and returns a list of instructions.  It
 does this by searching for an appropriate command-specific parsing function
-in @code{loopy-command-aliases} and ultimately in @code{loopy-command-parsers}.  For
+in @code{loopy-aliases} and ultimately in @code{loopy-command-parsers}.  For
 parsing multiple commands in order, there is @code{loopy--parse-loop-commands},
 which wraps the single-command version.
 

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -36,6 +36,7 @@
 
 ;;; Code:
 
+;; NOTE: This file can't require any of the other `loopy' files.
 (require 'cl-lib)
 (require 'gv)
 (require 'pcase)

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -7,6 +7,7 @@
 (require 'cl-lib)
 (require 'map)
 (require 'ert)
+(require 'map "./dependecy-links/map.el" 'no-error)
 (require 'loopy "./loopy.el")
 
 ;; "loopy quote"
@@ -3997,8 +3998,8 @@ This assumes that you're on guix."
 
 ;;; Custom Aliases
 (ert-deftest custom-alias-flag ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'f 'flag)))
+  (let ((loopy-aliases (map-copy loopy-aliases)))
+    (loopy-defalias f flag)
     (should (equal '((1) (2))
                    (eval (quote (loopy (f split)
                                        (list i '(1))
@@ -4006,15 +4007,15 @@ This assumes that you're on guix."
                                        (collect (1+ i)))))))))
 
 (ert-deftest custom-aliases-with ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'as 'with)))
+  (let ((loopy-aliases ))
+    (loopy-defalias as with)
     (should (= 1
                (eval (quote (loopy (as (a 1))
                                    (return a))))))))
 
 (ert-deftest custom-aliases-without ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'ignore 'without)))
+  (let ((loopy-aliases (map-copy loopy-aliases)))
+    (loopy-defalias 'ignore 'without)
     (should (= 5 (let ((a 1)
                        (b 2))
                    (eval (quote (loopy (ignore a b)
@@ -4024,23 +4025,23 @@ This assumes that you're on guix."
                    (+ a b))))))
 
 (ert-deftest custom-aliases-before-do ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'precode 'before-do)))
+  (let ((loopy-aliases (map-copy loopy-aliases)))
+    (loopy-defalias 'precode 'before-do)
     (should (= 7 (eval (quote (loopy (with (i 2))
                                      (precode (setq i 7))
                                      (return i))))))))
 
 (ert-deftest custom-aliases-after-do ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'postcode 'after-do)))
+  (let ((loopy-aliases (map-copy loopy-aliases)))
+    (loopy-defalias postcode after-do)
     (should (eval (quote (loopy (with (my-ret nil))
                                 (list i '(1 2 3 4))
                                 (postcode (setq my-ret t))
                                 (finally-return my-ret)))))))
 
 (ert-deftest custom-aliases-finally-do ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'fd 'finally-do)))
+  (let ((loopy-aliases (map-copy loopy-aliases)))
+    (loopy-defalias 'fd finally-do)
     (should
      (= 10
         (let (my-var)
@@ -4049,14 +4050,14 @@ This assumes that you're on guix."
           my-var)))))
 
 (ert-deftest custom-aliases-finally-return ()
-  (let ((loopy-command-aliases (map-insert loopy-command-aliases
-                                           'fr 'finally-return)))
+  (let ((loopy-aliases  (map-copy loopy-aliases)))
+    (loopy-defalias fr 'finally-return)
     (should (= 10
                (eval (quote (loopy (list i (number-sequence 1 10))
                                    (fr i))))))))
 
 (ert-deftest custom-aliases-list ()
-  (let ((loopy-command-aliases nil))
+  (let ((loopy-aliases nil))
     (should (loopy-defalias l list))
     (should (loopy-defalias a 'array))
     (should (equal '((1 . 4) (2 . 5) (3 . 6))


### PR DESCRIPTION
Fixes #100.

- [x] Rename `loopy-command-aliases` to `loopy-aliases`.
  - TBD: Separate commands aliases from those for special macro arguments?
- [x] Move built-in command aliases to `loopy-aliases`.
- [x] Try to simplify how aliases for special macro arguments are handled.
  - TODO: Do we need special handling for `let*` for `with` in `loopy-iter`.
- [x] Go through code, removing special handling of aliases.
  - Variables:
    - [x] `loopy--valid-macro-arguments`?
    - [x] `loopy--accumulation-constructors`
  - Functions:
    - [x] `loopy-iter--sub-loop-command-p`
    - [x] anywhere using `loopy--find-all-names`
    - [x] in the `loopy` and `loopy-iter` macro definitions