### PR TITLE
Fix setting and cleaning up internal stack variables in `loopy-iter`.

### DIFF
--- a/tests/tests.el
+++ b/tests/tests.el
@@ -4080,5 +4080,26 @@ This assumes that you're on guix."
                                        (a j [4 5 6])
                                        (collect (cons i j)))))))))
 
+;;; Clean Stack Variables
+(ert-deftest clean-stack-variables ()
+  (let (loopy--known-loop-names
+        loopy--accumulation-places
+        loopy--at-instructions
+        loopy--accumulation-list-end-vars
+        loopy--accumulation-variable-info)
+    (should (equal '((3 4) (1 2) 1 2 3 4)
+                   (eval (quote (loopy my-loop
+                                       (array i [(1 2) (3 4)])
+                                       (collect i :at start)
+                                       (loop inner
+                                             (list j i)
+                                             (at my-loop (collect j :at end))))))))
+    (should-not (or loopy--known-loop-names
+                    loopy--accumulation-places
+                    loopy--at-instructions
+                    loopy--accumulation-list-end-vars
+                    loopy--accumulation-variable-info))))
+
+
 ;; Local Variables:
 ;; End:


### PR DESCRIPTION
These are those used for optimizing accumulation commands, not accumulation
variables from stack commands.

We were not using the new function `loopy--clean-up-stack-vars`, as we were in
`loopy`.

- Use that function in `loopy-iter`.
- Remove old commented out code from `loopy-iter` body.
- Remove old code that set up some of those stack variables.  The new code was
  already in place, which caused loop names to be inserted twice into some
  variables.

This bug was found in #109, though is not related to the topic of that issue.