### PR TITLE
Add special macro argument `named`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,16 +118,22 @@ This document describes the user-facing changes to Loopy.
   accumulating version of `set`.  It is a generalization of the other generic
   accumulation commands `accumulate` and `reduce`.  See [#125] and [#129].
 
+- The new special macro argument `named` was added.  It is another way of
+  specifying loop names, instead of just listing a symbol.  This might be useful
+  in `loopy-iter`.  See issue [#123] and PR [#132].
+
 [#104]: https://github.com/okamsn/loopy/issues/104
 [#117]: https://github.com/okamsn/loopy/pull/117
 [#118]: https://github.com/okamsn/loopy/pull/118
 [#119]: https://github.com/okamsn/loopy/pull/119
+[#123]: https://github.com/okamsn/loopy/issues/123
 [#124]: https://github.com/okamsn/loopy/issues/124
 [#125]: https://github.com/okamsn/loopy/issues/125
 [#127]: https://github.com/okamsn/loopy/issues/127
 [#129]: https://github.com/okamsn/loopy/pull/129
 [#130]: https://github.com/okamsn/loopy/pull/130
 [#131]: https://github.com/okamsn/loopy/pull/131
+[#132]: https://github.com/okamsn/loopy/pull/132
 
 ## 0.10.1
 

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -274,15 +274,33 @@ explained in detail later in this document.
 :END:
 
 #+cindex: special macro argument
-There are only a few special macro arguments.  One, an unquoted symbol, is taken
-as the loop's name.  The others, listed below, are parenthesized expressions
-that begin with a keyword or one of their aliases.
-
-If a macro argument does not match one of these special few, ~loopy~ will
-attempt to interpret it as a loop command, and signal an error if that fails.
+There are only a few special macro arguments.  If a macro argument does not
+match one of these special few, ~loopy~ will attempt to interpret it as a loop
+command, and signal an error if that fails.
 
 These special macro arguments are always processed before loop commands,
 regardless of the order of the arguments passed to ~loopy~.
+
+#+findex: named
+- =named= or just a symbol :: Name the loop.  This also names the ~cl-block~
+  which contains the loop.  This can be of the form =(named NAME)= or just
+  =NAME=.
+
+  #+begin_src emacs-lisp
+    ;; => 3
+    (loopy outer
+           (array i [(1 2) (3 4) (5 6)])
+           (loopy (list j i)
+                  (when (> j 2)
+                    (return-from outer j))))
+
+    ;; => 3
+    (loopy (named outer)
+           (array i [(1 2) (3 4) (5 6)])
+           (loopy (list j i)
+                  (when (> j 2)
+                    (return-from outer j))))
+  #+end_src
 
 #+findex: with
 #+findex: let*
@@ -3160,7 +3178,7 @@ in their respective examples.
 
   #+BEGIN_SRC emacs-lisp
     ;; => 'bad-val?
-    (loopy outer-loop
+    (loopy (named outer-loop)
            (list inner-list '((1 2 3) (1 bad-val? 1) (4 5 6)))
            (loopy (list i inner-list)
                   (when (eq i 'bad-val?)
@@ -3206,7 +3224,7 @@ processed during the expansion of the top-level macro.
 
 #+begin_src emacs-lisp
   ;; Raises an error:
-  (loopy outer
+  (loopy (named outer)
          (list i '((1 2) (3 4) (5 6)))
          (do (loopy (list j i)
                     (when (= j 5)
@@ -3441,14 +3459,14 @@ arguments that are recognized by default is given in the section
 #+begin_src emacs-lisp
   ;; In `loopy', `list' is unambiguously a command name.
   ;; => (1 2 3 4)
-  (loopy outer
+  (loopy (named outer)
          (list i '((1 2) (3 4)))
          (loop (list j i)
                (at outer (collect j))))
 
   ;; In `loopy-iter', `list' would be a function.  `listing' is the command.
   ;; => (1 2 3 4)
-  (loopy-iter outer
+  (loopy-iter (named outer)
               (listing i '((1 2) (3 4)))
               (loopy-iter (listing j i)
                           ;; Can use `at' instead of `atting':
@@ -4137,7 +4155,7 @@ accumulation itself must still occur within the loop =inner=.
 
 #+begin_src emacs-lisp
   ;; => (1 2 3 4)
-  (loopy outer
+  (loopy (named outer)
          (array i [(1 2) (3 4)])
          (sub-loop inner
                    (list j i)
@@ -4715,18 +4733,18 @@ evaluates to ~nil~.
 ~loopy~ also provides the command =cond=, which works like the normal Lisp
 special form ~cond~.
 
-| ~cl-loop~              | ~loopy~                                     |
-|------------------------+---------------------------------------------|
-| =with var = value=     | =(with (VAR VALUE))= as a macro argument    |
-| =if COND clause=       | =(if COND CMDS)= as a loop command          |
-| =when COND clause=     | =(when COND CMDS)= as a loop command        |
-| =unless COND clause=   | =(unless COND CMDS)= as a loop command      |
-| =named NAME=           | =NAME= as a macro argument                  |
-| =initially [do] EXPRS= | =(before-do EXPRS)= as a macro argument     |
-| =finally [do] EXPRS=   | =(finally-do EXPRS)= as a macro argument    |
-| =finally return EXPR=  | =(finally-return EXPR)= as a macro argument |
-| =do EXPRS=             | =(do EXPRS)= as a loop command              |
-| =return EXPR=          | =(return EXPR)= as a loop command           |
+| ~cl-loop~              | ~loopy~                                       |
+|------------------------+-----------------------------------------------|
+| =with var = value=     | =(with (VAR VALUE))= as a macro argument      |
+| =if COND clause=       | =(if COND CMDS)= as a loop command            |
+| =when COND clause=     | =(when COND CMDS)= as a loop command          |
+| =unless COND clause=   | =(unless COND CMDS)= as a loop command        |
+| =named NAME=           | =NAME= or =(named NAME)= as a macro argument  |
+| =initially [do] EXPRS= | =(before-do EXPRS)= as a macro argument       |
+| =finally [do] EXPRS=   | =(finally-do EXPRS)= as a macro argument      |
+| =finally return EXPR=  | =(finally-return EXPR)= as a macro argument   |
+| =do EXPRS=             | =(do EXPRS)= as a loop command                |
+| =return EXPR=          | =(return EXPR)= as a loop command             |
 
 * Macro Argument and Loop Command Index
   :PROPERTIES:

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -303,15 +303,36 @@ explained in detail later in this document.
 @chapter Special Macro Arguments
 
 @cindex special macro argument
-There are only a few special macro arguments.  One, an unquoted symbol, is taken
-as the loop's name.  The others, listed below, are parenthesized expressions
-that begin with a keyword or one of their aliases.
-
-If a macro argument does not match one of these special few, @code{loopy} will
-attempt to interpret it as a loop command, and signal an error if that fails.
+There are only a few special macro arguments.  If a macro argument does not
+match one of these special few, @code{loopy} will attempt to interpret it as a loop
+command, and signal an error if that fails.
 
 These special macro arguments are always processed before loop commands,
 regardless of the order of the arguments passed to @code{loopy}.
+
+@findex named
+@table @asis
+@item @samp{named} or just a symbol
+Name the loop.  This also names the @code{cl-block}
+which contains the loop.  This can be of the form @samp{(named NAME)} or just
+@samp{NAME}.
+
+@lisp
+;; => 3
+(loopy outer
+       (array i [(1 2) (3 4) (5 6)])
+       (loopy (list j i)
+              (when (> j 2)
+                (return-from outer j))))
+
+;; => 3
+(loopy (named outer)
+       (array i [(1 2) (3 4) (5 6)])
+       (loopy (list j i)
+              (when (> j 2)
+                (return-from outer j))))
+@end lisp
+@end table
 
 @findex with
 @findex let*
@@ -667,7 +688,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting to do something like the below example might not do what you expect,
 as @samp{i} is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,org52084a8
+@float Listing,org66e50b5
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -789,7 +810,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,orgf3bb3a1
+@float Listing,orgb3d4c54
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -804,7 +825,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,org1a24ff9
+@float Listing,org4b66f34
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -3413,7 +3434,7 @@ returning @samp{[EXPRS]}.
 
 @lisp
 ;; => 'bad-val?
-(loopy outer-loop
+(loopy (named outer-loop)
        (list inner-list '((1 2 3) (1 bad-val? 1) (4 5 6)))
        (loopy (list i inner-list)
               (when (eq i 'bad-val?)
@@ -3463,7 +3484,7 @@ processed during the expansion of the top-level macro.
 
 @lisp
 ;; Raises an error:
-(loopy outer
+(loopy (named outer)
        (list i '((1 2) (3 4) (5 6)))
        (do (loopy (list j i)
                   (when (= j 5)
@@ -3712,14 +3733,14 @@ arguments that are recognized by default is given in the section
 @lisp
 ;; In `loopy', `list' is unambiguously a command name.
 ;; => (1 2 3 4)
-(loopy outer
+(loopy (named outer)
        (list i '((1 2) (3 4)))
        (loop (list j i)
              (at outer (collect j))))
 
 ;; In `loopy-iter', `list' would be a function.  `listing' is the command.
 ;; => (1 2 3 4)
-(loopy-iter outer
+(loopy-iter (named outer)
             (listing i '((1 2) (3 4)))
             (loopy-iter (listing j i)
                         ;; Can use `at' instead of `atting':
@@ -3764,7 +3785,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-aliases}.
 
-@float Listing,orgc3b0083
+@float Listing,org47c4f93
 @lisp
 ;; => ((1 2 3) (-3 -2 -1) (0))
 (loopy-iter (arg accum-opt positives negatives other)
@@ -4607,7 +4628,7 @@ accumulation itself must still occur within the loop @samp{inner}.
 
 @lisp
 ;; => (1 2 3 4)
-(loopy outer
+(loopy (named outer)
        (array i [(1 2) (3 4)])
        (sub-loop inner
                  (list j i)
@@ -5255,7 +5276,7 @@ evaluates to @code{nil}.
 @code{loopy} also provides the command @samp{cond}, which works like the normal Lisp
 special form @code{cond}.
 
-@multitable {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+@multitable {aaaaaaaaaaaaaaaaaaaaaa} {aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
 @headitem @code{cl-loop}
 @tab @code{loopy}
 @item @samp{with var = value}
@@ -5267,7 +5288,7 @@ special form @code{cond}.
 @item @samp{unless COND clause}
 @tab @samp{(unless COND CMDS)} as a loop command
 @item @samp{named NAME}
-@tab @samp{NAME} as a macro argument
+@tab @samp{NAME} or @samp{(named NAME)} as a macro argument
 @item @samp{initially [do] EXPRS}
 @tab @samp{(before-do EXPRS)} as a macro argument
 @item @samp{finally [do] EXPRS}

--- a/tests/iter-tests.el
+++ b/tests/iter-tests.el
@@ -634,7 +634,7 @@ E.g., \"(let ((for list)) ...)\" should not try to operate on the
                                        (accum collect j))))))
 
   (should (equal '(2 3 4 5 6)
-                 (loopy-iter outer
+                 (loopy-iter (named outer)
                              (listing i '(1 2 3 4 5))
                              (looping
                               (repeating 1)
@@ -644,7 +644,7 @@ E.g., \"(let ((for list)) ...)\" should not try to operate on the
 
 (ert-deftest loopy-iter-sub-loop ()
   (should (equal '(2 3 4 5 6)
-                 (loopy-iter outer
+                 (loopy-iter (named outer)
                              (for list i '(1 2 3 4 5))
                              (loopy-iter
                               (for repeat 1)
@@ -701,12 +701,13 @@ E.g., \"(let ((for list)) ...)\" should not try to operate on the
 
 (ert-deftest loopy-iter-command ()
   (should (equal '(11 12 13 14 15 16)
-                 (loopy outer
-                        (list i '((1 2) (3 4) (5 6)))
-                        (loopy-iter (for list j i)
-                                    (for at outer
-                                         (let ((val 10))
-                                           (accum collect (+ val j))))))))
+                 (eval (quote (loopy (named outer)
+                                     (list i '((1 2) (3 4) (5 6)))
+                                     (loopy-iter (for list j i)
+                                                 (for at outer
+                                                      (let ((val 10))
+                                                        (accum collect (+ val j)))))))
+                       t)))
 
   (should (equal '(11 12 13 14 15 16)
                  (loopy outer
@@ -898,6 +899,25 @@ E.g., \"(let ((for list)) ...)\" should not try to operate on the
   (should (loopy-iter (arg let* (a 3) ((b c) '(4 5)))
                       (repeating 3)
                       (collecting (list a b c)))))
+
+;;;; Named (loop Name)
+
+(ert-deftest named ()
+  (should (= 4 (eval (quote (loopy-iter my-loop
+                                        (returning-from my-loop 4)))
+                     t)))
+  (should (= 4 (eval (quote (loopy-iter (named my-loop)
+                                        (returning-from my-loop 4)))
+                     t)))
+  (should (equal '(4) (eval (quote (loopy-iter my-loop
+                                               (collecting 4)
+                                               (leaving-from my-loop)))
+                            t)))
+  (should (equal '(4) (eval (quote (loopy-iter (named my-loop)
+                                               (collecting 4)
+                                               (leaving-from my-loop)))
+                            t))))
+
 ;;;; With
 (ert-deftest with-arg-order ()
   (should (= 4
@@ -1854,11 +1874,12 @@ E.g., \"(let ((for list)) ...)\" should not try to operate on the
   (should (equal '(0 (1 . 4) (1 . 5) (2 . 4) (2 . 5))
                  (eval
                   (quote
-                   (loopy-iter outer
+                   (loopy-iter (named outer)
                                (listing i '(1 2))
                                (loopy-iter (listing j '(4 5))
                                            (at outer (collecting my-coll (cons i j))))
-                               (finally-return (cons 0 my-coll)))))))
+                               (finally-return (cons 0 my-coll))))
+                  t)))
 
   (should (equal "014152425"
                  (eval
@@ -4609,7 +4630,7 @@ Not multiple of 3: 7")))
 (ert-deftest return-from-outer-loop ()
   (should
    (= 6
-      (eval (quote (loopy-iter outer
+      (eval (quote (loopy-iter (named outer)
                                ;; Could use ‘sum’ command, but don’t want dependencies.
                                (with (sum 0))
                                (listing sublist '((1 2 3 4 5) (6 7 8 9) (10 11)))

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -36,6 +36,14 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
 
 
 ;;; Macro arguments
+;;;; Named (loop Name)
+
+(ert-deftest named ()
+  (should (= 4 (loopy my-loop (return-from my-loop 4))))
+  (should (= 4 (loopy (named my-loop) (return-from my-loop 4))))
+  (should (equal '(4) (loopy my-loop (collect 4) (leave-from my-loop))))
+  (should (equal '(4) (loopy (named my-loop) (collect 4) (leave-from my-loop)))))
+
 ;;;; With
 (ert-deftest with-arg-order ()
   (should (= 4
@@ -496,7 +504,7 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
                            (at outer (collect (cons i j)))))))
 
   (should (equal "14152425"
-                 (lq outer
+                 (lq (named outer)
                      (list i '("1" "2"))
                      (loop (list j '("4" "5"))
                            (at outer (concat (concat i j)))))))
@@ -517,7 +525,7 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
                      (finally-return (cons 0 my-coll)))))
 
   (should (equal "014152425"
-                 (lq outer
+                 (lq (named outer)
                      (list i '("1" "2"))
                      (loop (list j '("4" "5"))
                            (at outer (concat my-str (concat i j))))
@@ -545,7 +553,7 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
                       (collect i)))))
 
 (ert-deftest sub-loop-return-from-outer ()
-  (should (= 3 (lq outer
+  (should (= 3 (lq (named outer)
                    (list i '(1 2 3))
                    (loop (list j '(4 5 6 3))
                          (when (= j i)
@@ -578,11 +586,12 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
 
 (ert-deftest at-accum ()
   (should (equal '(1 2 3 4 5 6)
-                 (loopy outer
-                        (list i '((1 2) (3 4) (5 6)))
-                        (loopy (list j i)
-                               (at outer
-                                   (collect j)))))))
+                 (eval (quote (loopy (named outer)
+                                     (list i '((1 2) (3 4) (5 6)))
+                                     (loopy (list j i)
+                                            (at outer
+                                                (collect j)))))
+                       t))))
 
 (ert-deftest at-leave ()
   (should (equal '(1 2 3)
@@ -636,7 +645,7 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
                      (finally-return (cons 0 my-coll)))))
 
   (should (equal "014152425"
-                 (lq outer
+                 (lq (named outer)
                      (list i '("1" "2"))
                      (loopy (list j '("4" "5"))
                             (at outer (concat my-str (concat i j))))
@@ -3507,12 +3516,13 @@ Not multiple of 3: 7")))
 
 (ert-deftest skip-from ()
   (should (equal '((1 2 3) (7 8 9))
-                 (loopy outer
-                        (array i [(1 2 3) (4 5 6) (7 8 9)])
-                        (loopy (list j i)
-                               (if (= 5 j)
-                                   (skip-from outer)))
-                        (collect i)))))
+                 (eval (quote (loopy (named outer)
+                                     (array i [(1 2 3) (4 5 6) (7 8 9)])
+                                     (loopy (list j i)
+                                            (if (= 5 j)
+                                                (skip-from outer)))
+                                     (collect i)))
+                       t))))
 
 ;;;;; While
 (ert-deftest while ()


### PR DESCRIPTION
This is another way of naming the loop, which was previously only given by a
symbol in the macro arguments.  This might be helpful with `loopy-iter`.

- Update Org doc, Texinfo file, and change log.  Use `named` in some examples.
- Add tests of `loopy` and `loopy-iter`.
- Create function `loopy-iter--process-special-arg-loop-name`.  Use in
  `loopy-iter`.