### PR TITLE
Simple speed improvements.

### DIFF
--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -1003,5 +1003,29 @@ This expansion can apply FUNC directly or via `funcall'."
       `(,(loopy--get-function-symbol func) ,@args)
     `(funcall ,func ,@args)))
 
+;;;; Indexing
+
+(defun loopy--generate-inc-idx-instructions
+    (index-holder increment-holder by decreasing)
+  "Generate instructions for incrementing an index variable.
+
+If possible, directly use a number in the code instead of storing
+it in a variable, since that seems to be faster.
+
+INDEX-HOLDER is the variable use for index.
+INCREMENT-HOLDER is the variable to store the increment.
+BY is the increment passed in the parsing function.
+DECREASING is whether the increment should be decreasing.
+
+Returns a list of instructions."
+  (if (numberp by)
+      `((loopy--latter-body
+         (setq ,index-holder (,(if decreasing #'- #'+)
+                              ,index-holder ,by))))
+    `((loopy--iteration-vars (,increment-holder ,by))
+      (loopy--latter-body
+       (setq ,index-holder (,(if decreasing #'- #'+)
+                            ,index-holder ,increment-holder))))))
+
 (provide 'loopy-misc)
 ;;; loopy-misc.el ends here


### PR DESCRIPTION
- If `:by` is a number, use it directly.  This seems to make things noticeably
  faster, at least as far as the benchmarks in the wiki go.
  - `array`
  - `array-ref`
  - `seq`
  - `seq-index`
  - `seq-ref`
  - `numbers`

- In `seq`, only calculate the length of the sequence when it's an array.
  We don't do this for `seq-ref` or `seq-index`, since we're basically just
  iterating through numeric indices in those, not values.

- Note that using `consp` is faster than not using it, somehow.