### PR TITLE
Use Compat for `setf` on `plist-get` instead of copying the upstream definition.

### DIFF
--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -30,7 +30,7 @@
 
 ;; NOTE: This file can't require any of the other `loopy' files.
 (require 'cl-lib)
-(require 'gv)
+(require 'compat)
 (require 'pcase)
 (require 'seq)
 (require 'subr-x)
@@ -183,27 +183,6 @@ splitting (1 2 3) or (1 2 . 3) returns ((1 2) 3)."
 (defun loopy--var-ignored-p (var)
   "Return whether VAR should be ignored."
   (eq var '_))
-
-;; This was added to Emacs in commit 66509f2ead423b814378a44a55c9f63dcb1e149b.
-;; We copy that definition here for lower versions, since we use it for
-;; processing `&key' keys in the new destructuring features.
-(unless (and (<= 28 emacs-major-version)
-	     (function-get #'plist-get 'gv-expander))
-  (require 'gv)
-  (require 'macroexp)
-  (gv-define-expander plist-get
-    (lambda (do plist prop)
-      (macroexp-let2 macroexp-copyable-p key prop
-	(gv-letplace (getter setter) plist
-          (macroexp-let2 nil p `(cdr (plist-member ,getter ,key))
-            (funcall do
-                     `(car ,p)
-                     (lambda (val)
-                       `(if ,p
-                            (setcar ,p ,val)
-                          ,(funcall setter
-                                    `(cons ,key
-                                           (cons ,val ,getter))))))))))))
 
 ;;;;; Destructuring normal values
 ;;
@@ -912,8 +891,8 @@ See `loopy--destructure-list' for normal values."
                                                   ,value-expression))
                                     value-expression)))
           (dolist (k key-vars)
-            (push `(,k (plist-get ,key-target-value
-                                  ,(intern (format ":%s" k))))
+            (push `(,k (compat-call plist-get ,key-target-value
+                                    ,(intern (format ":%s" k))))
                   bindings)))))
 
     ;; Fix the order of the bindings and return.

--- a/loopy-pkg.el
+++ b/loopy-pkg.el
@@ -2,6 +2,7 @@
   "A looping macro"
   '((emacs "27.1")
     (map   "3.0")
-    (seq   "2.22"))
+    (seq   "2.22")
+    (compat "29.1.3"))
   :homepage "https://github.com/okamsn/loopy"
   :keywords '("extensions"))

--- a/loopy.el
+++ b/loopy.el
@@ -6,7 +6,7 @@
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
 ;; Version: 0.11.0
-;; Package-Requires: ((emacs "27.1") (map "3.0") (seq "2.22"))
+;; Package-Requires: ((emacs "27.1") (map "3.0") (seq "2.22") (compat "29.1.3"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs Edebug
 


### PR DESCRIPTION
We were adding the generalized variable on certain versions of Emacs if the property for the generalized didn't exist.