### PR TITLE
Fix error in optimized `nconc` end tracking.

### DIFF
--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -2297,7 +2297,7 @@ VAR."
         ;; Reverse list order.
         (loopy--check-accumulation-compatibility loop var 'reverse-list cmd)
         `(,@(if (eq pos 'start)
-                (loopy--produce-multi-item-end-tracking var val 'destructive)
+                (loopy--produce-multi-item-end-tracking var `(nreverse ,val) 'destructive)
               `((loopy--main-body (setq ,var (nconc (nreverse  ,val) ,var)))))
           (loopy--vars-final-updates
            (,var . (setq ,var (nreverse ,var)))))))))

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -2929,13 +2929,13 @@ INPUT is the destructuring usage.  OUTPUT-PATTERN is what to match."
   (should (equal '(5 6 3 4 1 2)
                  (loopy (accum-opt (coll end))
                         (list i (list (list 1 2) (list 3 4) (list 5 6)))
-                        (append coll i :at start)
+                        (nconc coll i :at start)
                         (finally-return coll))))
 
   (should (equal '(1 2 3 4 5 6)
                  (loopy (accum-opt (coll start))
                         (list i (list (list 1 2) (list 3 4) (list 5 6)))
-                        (append coll i :at end)
+                        (nconc coll i :at end)
                         (finally-return coll))))
 
   (should (equal '(5 6 3 4 1 2 11 12 13 14 15 16)


### PR DESCRIPTION
The value should be `nreverse`-ed when prepending to a backwards list,
but wasn't in all cases.

This error was also made in `loopy--construct-accum-append`, though it was fixed
there a few months ago.