### PR TITLE
Fix `nunion` for union-ing at the start of end-optimized collections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document describes the user-facing changes to Loopy.
 
+## Unreleased
+
+- Fix `nunion` for appending onto the start of end-optimized lists.
+
 ## 0.11.1
 
 Released 2023-03-13.

--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -2369,7 +2369,7 @@ This function is used by `loopy--get-optimized-accum'."
           (loopy--check-accumulation-compatibility
            loopy--loop-name var 'reverse-list cmd)
           `(,@(if (eq pos 'start)
-                  (loopy--produce-union-end-tracking var val test-method 'destructive)
+                  (loopy--produce-union-end-tracking var `(nreverse ,val) test-method 'destructive)
                 `((loopy--main-body
                    (setq ,var (nconc (nreverse (cl-delete-if ,test-method ,val))
                                      ,var)))))


### PR DESCRIPTION
This problem found while updating tests for new testing macro.