### PR TITLE
Fix `reduce` with no explicit initialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ This document describes the user-facing changes to Loopy.
   `collect`.  This change makes these commands work with the new system for
   optimized accumulation variables.
 
+- Without an explicit starting value for the accumulation variable, `reduce` now
+  uses the first accumulated value without passing it to the function.  This is
+  how reducing actually works, and was the intended behavior. Previously, the
+  function was always called. _This is a breaking change._ See [#164].
+
+  ```emacs-lisp
+  ;; Now correct behavior (would previously error):
+  ;; => 6
+  (loopy (list i '(1 2 3))
+         (reduce i #'*))
+  ```
+
 ### Breaking Changes
 
 - Make it an error to re-use iteration variables with multiple iteration
@@ -92,6 +104,9 @@ This document describes the user-facing changes to Loopy.
 - Add `loopy--other-vars`, given the more explicit restriction on
   `loopy--iteration-vars`.  For example, these are the variables bound by the
   `set` command, which are allowed to occur in more than one command.
+
+[#164]: https://github.com/okamsn/loopy/pull/164
+
 
 ## 0.11.2
 

--- a/README.org
+++ b/README.org
@@ -48,6 +48,9 @@ please let me know.
      special macro arguments, possibly with =accum-opt=.
    - The =:init= keyword argument is deprecated.  Use the special macro argument
      =with= instead.
+   - =reduce= has been fixed. It now works like ~cl-reduce~ when the variable
+     starting value isn't explicitly given, storing the first value instead of
+     storing the result of passing the first value and ~nil~ to the function.
  - Versions 0.11.1 and 0.11.2: None. Bug fixes.
  - Version 0.11.0:
    - More incorrect destructured bindings now correctly signal an error.

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -2347,32 +2347,40 @@ using the =set= command.
 
 #+findex: reduce
 #+findex: reducing
-- =(reduce VAR EXPR FUNC)= :: Reduce =EXPR= into =VAR= by =FUNC=.  =FUNC= is
-  called with =VAR= as the first argument and =EXPR= as the second argument.
-  This is unlike =accumulate=, which gives =VAR= and =EXPR= to =FUNC= in the
-  opposite order (that is, =EXPR= first, then =VAR=).
+- =(reduce VAR EXPR FUNC)= :: Reduce =EXPR= into =VAR= by =FUNC=, like in
+  ~cl-reduce~.  =FUNC= is called with =VAR= as the first argument and =EXPR= as
+  the second argument.  This is unlike =accumulate=, which gives =VAR= and
+  =EXPR= to =FUNC= in the opposite order (that is, =EXPR= first, then =VAR=).
 
   This command also has the alias =reducing=.
+
+  When =VAR= does not have an explicit starting value (given with the special
+  macro argument =with=), the first accumulated value is =EXPR=.  The first
+  accumulated value is not the result of passing =VAR= and =EXPR= to =FUNC=.
+  Using the =with= special macro argument is similar to using ~cl-reduce~'s
+  =:initial-value= keyword argument.
 
   This command is similar in effect to the =set= command.
 
   #+begin_src emacs-lisp
+    ;; => 6
+    (loopy (list i '(1 2 3))
+           (reduce i #'*))
+
+    ;; Similar to the above:
+    (loopy (list i '(1 2 3))
+           (set loopy-result i (* i loopy-result))
+           (finally-return loopy-result))
+
     ;; = > 6
     (loopy (with (my-reduction 0))
            (list i '(1 2 3))
            (reduce my-reduction i #'+)
            (finally-return my-reduction))
 
-    ;; Works similarly to above:
-    (loopy (with (my-reduction 0))
-           (list i '(1 2 3))
-           (set my-reduction (+ i my-reduction))
-           (finally-return my-reduction))
-
-    ;; => 24
-    (loopy (with (loopy-result 1))
-           (list i '(1 2 3 4))
-           (reduce i #'*))
+    ;; Similar to the above:
+    (cl-reduce #'+ (list 1 2 3) :initial-value 0)
+    (seq-reduce #'+ [1 2 3] 0)
   #+end_src
 
   This command also has the alias =callf=.  It is similar to using the

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -4160,6 +4160,24 @@ Using `start' and `end' in either order should give the same result."
   :iter-bare ((list . listing)
               (_cmd . (reducing))))
 
+(loopy-deftest reduce-no-init
+  :doc "When the accumulation variable isn't explicitly initialized,
+`reduce' should store the first value without calling the function.
+
+This is how `cl-reduce' and `seq-reduce' work."
+  :result (cl-reduce #'+ '(1 2 3))
+  :multi-body t
+  :body [((list i '(1 2 3))
+          (reduce r i #'+)
+          (finally-return r))
+
+         ((list i '(1 2 3))
+          (reduce i #'+))]
+  :loopy t
+  :iter-keyword (list reduce)
+  :iter-bare ((list . listing)
+              (reduce . reducing)))
+
 (loopy-deftest reduce-with
   :doc "Test that we can replace `:init' with `with'."
   :result 6
@@ -4198,9 +4216,20 @@ Using `start' and `end' in either order should give the same result."
 
 (loopy-deftest reduce-destructuring-+
   :result '(4 6)
-  :body ((list i '((1 2) (3 4)))
-         (reduce (r1 r2) i #'+ :init 0)
-         (finally-return r1 r2))
+  :multi-body t
+  :body [((with (r1 0)
+                (r2 0))
+          (list i '((1 2) (3 4)))
+          (reduce (r1 r2) i #'+)
+          (finally-return r1 r2))
+
+         ((list i '((1 2) (3 4)))
+          (reduce (r1 r2) i #'+ :init 0)
+          (finally-return r1 r2))
+
+         ((list i '((1 2) (3 4)))
+          (reduce (r1 r2) i #'+)
+          (finally-return r1 r2))]
   :loopy t
   :iter-keyword (list reduce)
   :iter-bare ((list . listing)


### PR DESCRIPTION
Change so that it does not pass the first value of `EXPR` to the function.  This
change makes it work more like `cl-reduce`, which is the expected behavior.