### PR TITLE
Bump version from 0.12.0 to 0.12.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document describes the user-facing changes to Loopy.
 
+## 0.12.1
+
+- Increase version number to so that the ELPA process uses the `.elpaignore`
+  file for the stable version of the package.
+
 ## 0.12.0
 
 ### Bugs Fixed

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.12.0
-;; Package-Requires: ((emacs "25.1") (loopy "0.12.0") (dash "2.19"))
+;; Version: 0.12.1
+;; Package-Requires: ((emacs "25.1") (loopy "0.12.1") (dash "2.19"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy-pkg.el
+++ b/loopy-pkg.el
@@ -1,4 +1,4 @@
-(define-package "loopy" "0.12.0"
+(define-package "loopy" "0.12.1"
   "A looping macro"
   '((emacs "27.1")
     (map   "3.3.1")

--- a/loopy.el
+++ b/loopy.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.12.0
+;; Version: 0.12.1
 ;; Package-Requires: ((emacs "27.1") (map "3.3.1") (seq "2.22") (compat "29.1.3"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs Edebug


### PR DESCRIPTION
Increase version number to so that the ELPA process uses the `.elpaignore`
file for the stable version of the package.