### PR TITLE
Bump to version 0.12.2 to correct the `.elpaignore` file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This document describes the user-facing changes to Loopy.
 
+## 0.12.2
+
+- Correct the `.elpaignore` file.
+
 ## 0.12.1
 
 - Increase version number to so that the ELPA process uses the `.elpaignore`

--- a/loopy-dash.el
+++ b/loopy-dash.el
@@ -5,8 +5,8 @@
 ;; Author: Earl Hyatt
 ;; Created: February 2021
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.12.1
-;; Package-Requires: ((emacs "25.1") (loopy "0.12.1") (dash "2.19"))
+;; Version: 0.12.2
+;; Package-Requires: ((emacs "25.1") (loopy "0.12.2") (dash "2.19"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs
 

--- a/loopy-pkg.el
+++ b/loopy-pkg.el
@@ -1,4 +1,4 @@
-(define-package "loopy" "0.12.1"
+(define-package "loopy" "0.12.2"
   "A looping macro"
   '((emacs "27.1")
     (map   "3.3.1")

--- a/loopy.el
+++ b/loopy.el
@@ -5,7 +5,7 @@
 ;; Author: Earl Hyatt
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
-;; Version: 0.12.1
+;; Version: 0.12.2
 ;; Package-Requires: ((emacs "27.1") (map "3.3.1") (seq "2.22") (compat "29.1.3"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs Edebug


### PR DESCRIPTION
Remove `loopy-pkg.el` from the file `.elpaignore`.  The file `.elpaignore` file
determines what goes into the tarball, not what is downloaded.  The repo
contains a file `loopy-pkg.el`, but the ELPA process also makes its own, which
should be included in the generated tarball so that the tarball can be installed
properly.