### PR TITLE
Remove the deprecated `:init` keyword argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This document describes the user-facing changes to Loopy.
 
+## Unreleased
+
+### Breaking Changes
+
+- The deprecated `:init` keyword argument has been removed ([#195], [#146]).
+  Use the `with` special macro argument instead.
+
+[#195]: https://github.com/okamsn/loopy/pull/195
+
 ## 0.12.2
 
 - Correct the `.elpaignore` file.

--- a/README.org
+++ b/README.org
@@ -30,6 +30,9 @@ please let me know.
 -----
 
  _Recent breaking changes:_
+ - Unreleased:
+   - The deprecated =:init= keyword argument has been removed.  Use the =with=
+     special macro argument instead.
  - Version 0.12.0:
    - The boolean commands =always=, =never=, and =thereis= now behave more like
      accumulation commands and use ~loopy-result~ by default.


### PR DESCRIPTION
`:init` is replaced by the special macro argument `:with`.  It was marked
deprecated by PR #163.

- Remove the relevant code.
- Remove the relevant tests.
- Edit a few tests.

See also issue #146.