### PR TITLE
Remove the deprecated `:result-type` keyword argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ This document describes the user-facing changes to Loopy.
 - The deprecated `:init` keyword argument has been removed ([#195], [#146]).
   Use the `with` special macro argument instead.
 
+- The deprecated `:result-type` keyword argument has been removed ([#196],
+  [#154]).  Use the `finally-return` special macro argument instead in
+  combination with `cl-coerce`, `seq-into`, or a similar function.
+
 [#195]: https://github.com/okamsn/loopy/pull/195
+[#196]: https://github.com/okamsn/loopy/pull/196
 
 ## 0.12.2
 

--- a/README.org
+++ b/README.org
@@ -33,6 +33,9 @@ please let me know.
  - Unreleased:
    - The deprecated =:init= keyword argument has been removed.  Use the =with=
      special macro argument instead.
+   - The deprecated =:result-type= keyword argument has been removed.  Use the
+     =finally-return= special macro argument instead in combination with
+     ~cl-coerce~, ~seq-into~, or a similar function.
  - Version 0.12.0:
    - The boolean commands =always=, =never=, and =thereis= now behave more like
      accumulation commands and use ~loopy-result~ by default.

--- a/loopy.el
+++ b/loopy.el
@@ -778,8 +778,7 @@ In `loopy', processing instructions is stateful."
        [":into" loopy--destr-var-name-edebug-spec]
        [":test" form]
        [":key" form]
-       [":init" form]
-       [":result-type" symbolp]])
+       [":init" form]])
 
 (def-edebug-spec loopy--command-edebug-specs
   [&or


### PR DESCRIPTION
This argument was deprecated in PR #162.
See also issue #154.

- Remove tests of `:result-type`.
- Remove the relevant code.
- Update test `acccumulation-conflicting-final-updates` to use custom commands
  instead of checking using `:result-type`.
- Make sure the accumulation category actually gets set when
  the `:category` argument is passed to `loopy--defaccumulation`.