### PR TITLE
Add `name` to `ignore` in `loopy--defaccumulation`.

### DIFF
--- a/loopy-commands.el
+++ b/loopy-commands.el
@@ -139,7 +139,7 @@ handled by `loopy-iter'."
 
 ;;;;; Genereric Evaluation
 ;;;;;; Set
-(cl-defun loopy--parse-set-command ((&whole cmd _ var &rest vals))
+(cl-defun loopy--parse-set-command ((_ var &rest vals))
   "Parse the `set' command.
 
 - VAR is the variable to assign.
@@ -190,7 +190,7 @@ handled by `loopy-iter'."
 ;;       being known at compile time (but still only being evaluated once.)
 ;;       (#194)
 (cl-defun loopy--parse-set-prev-command
-    ((&whole cmd _ var val &key back))
+    ((_ var val &key back))
   "Parse the `set-prev' command as (set-prev VAR VAL &key back).
 
 VAR is set to a version of VAL in a past loop cycle.  With BACK,
@@ -1777,7 +1777,7 @@ you can use in the instructions:
                               args (nreverse args-holding))
                       (setq args parser-args)))
 
-           (ignore args opts)
+           (ignore name args opts)
 
            (let ((arg-length (length args)))
              (cond

--- a/loopy-misc.el
+++ b/loopy-misc.el
@@ -457,11 +457,12 @@ KEY transforms those elements and ELEMENT."
 Prior to Emacs 28, it was not guaranteed that `pcase-let' bound
 unmatched variables."
   (declare (indent 1))
-  (if (eval-when-compile (< emacs-major-version 28))
+  (static-if (< emacs-major-version 28)
       `(let ,(mapcar (lambda (sym) `(,sym nil))
                      variables)
          ,(cons 'ignore variables)
          ,form)
+    (ignore variables)
     form))
 
 (provide 'loopy-misc)

--- a/tests/misc-tests.el
+++ b/tests/misc-tests.el
@@ -1167,14 +1167,14 @@ The valid keys are:
 
 ;; FIXME: This test fails on Emacs 27 because the tests don't install the
 ;;       correct version of Map.el.
-(when (> emacs-major-version 27)
-  (loopy-def-pcase-test pcase-tests-loopy-&optional-ignored-6
-    :result (list 1 2 [] 14 nil)
-    :val   (vector 1 2)
-    :var (a b e k1 k2)
-    :pat [a b &optional _ _ &rest e &map [:k1 k1 14] (:k2 k2)]
-    :list nil
-    :convert nil))
+(static-if (> emacs-major-version 27)
+    (loopy-def-pcase-test pcase-tests-loopy-&optional-ignored-6
+      :result (list 1 2 [] 14 nil)
+      :val   (vector 1 2)
+      :var (a b e k1 k2)
+      :pat [a b &optional _ _ &rest e &map [:k1 k1 14] (:k2 k2)]
+      :list nil
+      :convert nil))
 
 (loopy-def-pcase-test pcase-tests-loopy-&whole-1
   :result (list (list 1 2 3) 1 2 3)

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -5803,7 +5803,7 @@ Otherwise, `loopy' should return t."
   ;; Emacs 27 had a byte-compilation error that was fixed in
   ;; commit a0f60293d79cda858c033db4ae074e5e5560aab2.
   ;; See: https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=a0f60293d97cda858c033db4ae074e5e5560aab2.
-  :expected-result (if (= emacs-major-version 27)
+  :expected-result (static-if (= emacs-major-version 27)
                        :failed
                      :passed)
   (should


### PR DESCRIPTION
Silence byte-compiler warnings when `name` is unused.