### PR TITLE
Improve `set-prev`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,20 @@ This document describes the user-facing changes to Loopy.
   ([#197], [#145]).  These commands no longer take multiple conditions in the
   same command.
 
+### Bugs Fixed
+
+- Allow `back` in `set-prev` to not be known at compile time ([#202]).
+
+### Documentation Improvements
+
+- State explicitly that `set-prev` records values from the end
+  of each loop cycle and that it does not modify its variable
+  until the specified cycle ([#202]).
+
 [#195]: https://github.com/okamsn/loopy/pull/195
 [#196]: https://github.com/okamsn/loopy/pull/196
 [#197]: https://github.com/okamsn/loopy/pull/197
+[#202]: https://github.com/okamsn/loopy/pull/202
 
 ## 0.12.2
 

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1370,9 +1370,11 @@ value and do no affect how the loop iterates.
 #+findex: prev
 - =(set-prev|prev-expr VAR VAL &key back)= :: Bind =VAR= to a value =VAL= from a
   previous cycle in the loop.  With =BACK= (default: 1), use the value from that
-  many cycles previous.  This command /does not/ work like a queue; it always
-  uses the value from the =BACK=-th previous cycle, regardless of when the
-  command is run.
+  many cycles previous.  _If not enough cycles have passed yet, then the value
+  of =VAR= is not modified._  This command /does not/ work like a queue for
+  recording =VAL=; it always uses the value from the =BACK=-th previous cycle,
+  regardless of when the command is run.  The value used is always the value at
+  the end of the cycle.
 
   This command also has the aliases =setting-prev=, =prev-set=, and =prev=.
 
@@ -1383,10 +1385,13 @@ value and do no affect how the loop iterates.
            (collect j))
 
     ;; => (nil nil nil 1 2)
-    (loopy (list i '(1 2 3 4 5))
-           (set-prev j i :back 3)
+    (loopy (with (n 3))
+           (list i '(1 2 3 4 5))
+           (set-prev j i :back n)
            (collect j))
 
+    ;; NOTE: `j' isn't overwritten until the correct cycle:
+    ;;
     ;; => ((first-val nil) (first-val nil) (1 2) (3 4))
     (loopy (with (j 'first-val))
            (list i '((1 . 2) (3 . 4) (5 . 6) (7 . 8)))
@@ -1401,6 +1406,16 @@ value and do no affect how the loop iterates.
            (numbers i :from 1 :to 10)
            (when (cl-oddp i)
              (set-prev j i))
+           (collect j))
+
+    ;; NOTE: `j' is always bound to the previous value of `i'
+    ;;       from the end of the specified cycle.
+    ;;
+    ;; => (nil 101 102 103)
+    (loopy (numbers i :from 1 :to 4)
+           (set i2 i)
+           (set-prev j i2)
+           (set i2 (+ i 100))
            (collect j))
   #+end_src
 

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -876,9 +876,20 @@ SYMS-STR are the string names of symbols from `loopy-iter-bare-commands'."
 
 (loopy-deftest set-prev-keyword-back
   :result '(nil nil nil 1 2)
-  :body ((list i '(1 2 3 4 5))
-         (set-prev j i :back 3)
-         (collect j))
+  :multi-body t
+  :body [((list i '(1 2 3 4 5))
+          (set-prev j i :back 3)
+          (collect j))
+
+         ((with (n 3)
+                (first-time t))
+          (list i '(1 2 3 4 5))
+          (set-prev j i :back (if first-time
+                                  (progn
+                                    (setq first-time nil)
+                                    n)
+                                (error "Evaluated more than once.")))
+          (collect j))]
   :loopy t
   :iter-bare ((list . listing)
               (collect . collecting)


### PR DESCRIPTION
- Allow `back` to no be known at compile time.  Use a simple implementation
  of a queue, adapted from https://irreal.org/blog/?p=40.
  - Add a test of a `with`-bound `back`.

- State clearly in the documentation that `set-prev` stores the value
  of `VAL` found at the end of the loop cycle and that it does
  not modify `VAR` until the specified loop cycle.

See all issue #194.