### PR TITLE
Start removing logic for postion-based argument to the `numbers` command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ This document describes the user-facing changes to Loopy.
   error, use the `with` special macro argument to explicitly state a starting
   value for the accumulation variable.
 
+- Remove the deprecated positional arguments to the `numbers` command ([#205]).
+
 [#169]: https://github.com/okamsn/loopy/issues/169
 [#203]: https://github.com/okamsn/loopy/pull/203
+[#205]: https://github.com/okamsn/loopy/pull/205
 
 ## 0.13.0
 

--- a/README.org
+++ b/README.org
@@ -33,6 +33,8 @@ please let me know.
  - Unreleased:
    - Conflicting initialization values for accumulation variables now signal
      a warning.  In the future, they will signal an error.
+   - The positional arguments to the =numbers= command have been removed,
+     being deprecated since version 0.12.0.
  - Version 0.13.0:
    - The deprecated =:init= keyword argument has been removed.  Use the =with=
      special macro argument instead.

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1643,7 +1643,7 @@ variants =numbers-up= and =numbers-down=.
   #+begin_src emacs-lisp
     ;; => (7 8 9 10 11 12 13 14 15 16)
     (loopy (cycle 10)
-           (numbers i 7)
+           (numbers i :from 7)
            (collect i))
   #+end_src
 
@@ -1657,13 +1657,9 @@ variants =numbers-up= and =numbers-down=.
     (loopy (numbers i :from 1 :to 5 :by 2)
            (collect i))
 
-    ;; => (1 3 5)
-    (loopy (numbers i 1 5 2)
-           (collect i))
-
     ;; => (7 9 11 13 15 17 19 21 23 25)
     (loopy (cycle 10)
-           (numbers i 7 :by 2)
+           (numbers i :from 7 :by 2)
            (collect i))
 
     ;; => (1 2.5 4.0)
@@ -1675,9 +1671,9 @@ variants =numbers-up= and =numbers-down=.
   whether the value should be increasing or decreasing when using the =:by=
   keyword, one can use the keywords =:downfrom=, =:downto=, =:upfrom=, =:upto=,
   =:above=, and =:below=.  The keywords =:from= and =:to= don't by themselves
-  specify a direction, and they can be used with the keyword arguments that do
-  without conflict.  Using arguments that contradict one another will signal an
-  error.
+  specify a direction, and they can be used without conflict with the keyword
+  arguments that do.  Using arguments that contradict one another will signal
+  an error.
 
   #+begin_src emacs-lisp
     ;; => (3 2 1)
@@ -1701,7 +1697,7 @@ variants =numbers-up= and =numbers-down=.
     (loopy (numbers i :from 1 :upto 7)
            (collect i))
 
-    ;; => Signals an error:
+    ;; Signals an error:
     (loopy (numbers i :downfrom 10 :upto 20)
            (collect i))
   #+end_src
@@ -1771,7 +1767,7 @@ are simple wrappers of the above =numbers= command.
 #+findex: numbers-down
 #+findex: numbering-down
 - =(numbers-down|nums-down VAR START [END] &key by)= :: Equivalent to =(numbers
-  VAR START [:downto END] &key by)=.  This command exists only for convenience.
+  VAR :from START [:downto END] &key by)=.  This command exists only for convenience.
 
   This command also has the aliases =numsdown= and =numbering-down=.
 
@@ -1789,7 +1785,7 @@ are simple wrappers of the above =numbers= command.
 #+findex: numbers-up
 #+findex: numbering-up
 - =(numbers-up|nums-up VAR START [END] &key by)= :: Equivalent to =(numbers VAR
-  START [END] &key by)=.  This command exists only for convenience.
+  :from START [END] &key by)=.  This command exists only for convenience.
 
   This command also has the aliases =numsup= and =numbering-up=.
 

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -705,7 +705,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting something like the below example might not do what you expect, as @samp{i}
 is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,org60882dd
+@float Listing,org04e7c72
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -888,7 +888,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,orge44397f
+@float Listing,orga4486aa
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -903,7 +903,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,org9267070
+@float Listing,orgea59f47
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -1803,7 +1803,7 @@ end.
 @lisp
 ;; => (7 8 9 10 11 12 13 14 15 16)
 (loopy (cycle 10)
-       (numbers i 7)
+       (numbers i :from 7)
        (collect i))
 @end lisp
 
@@ -1817,13 +1817,9 @@ whether the variable is incremented or decremented.
 (loopy (numbers i :from 1 :to 5 :by 2)
        (collect i))
 
-;; => (1 3 5)
-(loopy (numbers i 1 5 2)
-       (collect i))
-
 ;; => (7 9 11 13 15 17 19 21 23 25)
 (loopy (cycle 10)
-       (numbers i 7 :by 2)
+       (numbers i :from 7 :by 2)
        (collect i))
 
 ;; => (1 2.5 4.0)
@@ -1835,9 +1831,9 @@ By default, the variable's value starts at 0 and increases by 1.  To specify
 whether the value should be increasing or decreasing when using the @samp{:by}
 keyword, one can use the keywords @samp{:downfrom}, @samp{:downto}, @samp{:upfrom}, @samp{:upto},
 @samp{:above}, and @samp{:below}.  The keywords @samp{:from} and @samp{:to} don't by themselves
-specify a direction, and they can be used with the keyword arguments that do
-without conflict.  Using arguments that contradict one another will signal an
-error.
+specify a direction, and they can be used without conflict with the keyword
+arguments that do.  Using arguments that contradict one another will signal
+an error.
 
 @lisp
 ;; => (3 2 1)
@@ -1861,7 +1857,7 @@ error.
 (loopy (numbers i :from 1 :upto 7)
        (collect i))
 
-;; => Signals an error:
+;; Signals an error:
 (loopy (numbers i :downfrom 10 :upto 20)
        (collect i))
 @end lisp
@@ -1933,7 +1929,7 @@ are simple wrappers of the above @samp{numbers} command.
 @table @asis
 @item @samp{(numbers-down|nums-down VAR START [END] &key by)}
 Equivalent to @samp{(numbers
-  VAR START [:downto END] &key by)}.  This command exists only for convenience.
+  VAR :from START [:downto END] &key by)}.  This command exists only for convenience.
 
 This command also has the aliases @samp{numsdown} and @samp{numbering-down}.
 
@@ -1953,7 +1949,7 @@ This command also has the aliases @samp{numsdown} and @samp{numbering-down}.
 @table @asis
 @item @samp{(numbers-up|nums-up VAR START [END] &key by)}
 Equivalent to @samp{(numbers VAR
-  START [END] &key by)}.  This command exists only for convenience.
+  :from START [END] &key by)}.  This command exists only for convenience.
 
 This command also has the aliases @samp{numsup} and @samp{numbering-up}.
 
@@ -4682,7 +4678,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-aliases}.
 
-@float Listing,org0f10623
+@float Listing,org5fa2cde
 @lisp
 ;; => ((1 2 3) (-3 -2 -1) (0))
 (loopy-iter (arg accum-opt positives negatives other)

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -899,7 +899,7 @@ SYMS-STR are the string names of symbols from `loopy-iter-bare-commands'."
 (loopy-deftest set-prev-keyword-with
   :result '(first-val first-val 2 2 4 4 6 6 8 8)
   :body ((with (j 'first-val))
-         (numbers i 1 10)
+         (numbers i :from 1 :to 10)
          (when (cl-oddp i)
            (set-prev j i))
          (collect j))
@@ -1833,7 +1833,7 @@ Using numbers directly will use less variables and more efficient code."
 (loopy-deftest numbers
   :result '(1 2 3 4 5)
   :repeat _cmd
-  :body ((_cmd i 1 5)
+  :body ((_cmd i :from 1 :to 5)
          (collect i))
   :loopy ((_cmd . (nums numbers num number)))
   :iter-keyword ((_cmd . (nums numbers num number))
@@ -1841,23 +1841,15 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((_cmd . (numbering))
               (collect . collecting)))
 
-(loopy-deftest numbers-pos-nokey-step
-  :result '(1 3 5)
+(loopy-deftest numbers-keywords-pos-args-should-error
+  :doc "Make sure an error is signaled when using the now removed positional arguments."
+  :error loopy-wrong-number-of-command-arguments-or-bad-keywords
   :body ((numbers i 1 5 2)
          (collect i))
   :loopy t
-  :iter-keyword (numbers collect)
-  :iter-bare ((numbers . numbering)
-              (collect . collecting)))
-
-(loopy-deftest numbers-neg-nokey-step
-  :result '(5 3 1)
-  :body (loopy (numbers i 5 1 -2)
-               (collect i))
-  :loopy t
-  :iter-keyword (numbers collect)
-  :iter-bare ((numbers . numbering)
-              (collect . collecting)))
+  :iter-keyword (collect numbers)
+  :iter-bare ((collect . collecting)
+              (numbers . numbering)))
 
 ;;;;; Nums Keywords
 
@@ -1996,17 +1988,13 @@ Using numbers directly will use less variables and more efficient code."
   :iter-keyword (numbers)
   :iter-bare ((numbers . numbering)))
 
-;;;;; Nums With Vars
+;;;;; Numbers With Vars
 (loopy-deftest numbers-literal-by-and-literal-end
   :doc "Check the optimizing for non-variable `:by' and `:to' doesn't fail."
   :result '(2 4 6 8)
-  :multi-body t
-  :body [((with (start 2))
-          (numbers i start 8 2)
-          (collect i))
-         ((with (start 2))
-          (numbers i start :to 8 :by 2)
-          (collect i))]
+  :body ((with (start 2))
+         (numbers i :from start :to 8 :by 2)
+         (collect i))
   :loopy t
   :iter-keyword (numbers collect)
   :iter-bare ((numbers . numbering)
@@ -2015,13 +2003,9 @@ Using numbers directly will use less variables and more efficient code."
 (loopy-deftest numbers-literal-by-with-var-end
   :doc "Check the optimizing for non-variable `:by' and variable `:to' doesn't fail."
   :result '(2 4 6 8)
-  :multi-body t
-  :body [((with (start 2) (end 8))
-          (numbers i start end 2)
-          (collect i))
-         ((with (start 2) (end 8))
-          (numbers i start :to end :by 2)
-          (collect i))]
+  :body ((with (start 2) (end 8))
+         (numbers i :from start :to end :by 2)
+         (collect i))
   :loopy t
   :iter-keyword (numbers collect)
   :iter-bare ((numbers . numbering)
@@ -2030,13 +2014,9 @@ Using numbers directly will use less variables and more efficient code."
 (loopy-deftest numbers-var-by-with-var-end
   :doc "Check the optimizing for variable `:by' and variable `:to' doesn't fail."
   :result '(2 4 6 8)
-  :multi-body t
-  :body [((with (start 2) (by 2) (end 8))
-          (numbers i start end by)
-          (collect i))
-         ((with (start 2) (by 2) (end 8))
-          (numbers i start :to end :by by)
-          (collect i))]
+  :body ((with (start 2) (by 2) (end 8))
+         (numbers i :from start :to end :by by)
+         (collect i))
   :loopy t
   :iter-keyword (numbers collect)
   :iter-bare ((numbers . numbering)
@@ -2047,7 +2027,7 @@ Using numbers directly will use less variables and more efficient code."
   :result '(2 4 6 8)
   :body ((with (start 2))
          (cycle 4)
-         (numbers i start :by 2)
+         (numbers i :from start :by 2)
          (collect i))
   :loopy t
   :iter-keyword (numbers collect cycle)
@@ -2060,7 +2040,7 @@ Using numbers directly will use less variables and more efficient code."
   :result '(2 4 6 8)
   :body ((with (start 2) (by 2))
          (cycle 4)
-         (numbers i start :by by)
+         (numbers i :from start :by by)
          (collect i))
   :loopy t
   :iter-keyword (numbers collect cycle)


### PR DESCRIPTION
- Simply the definition of `numbers` by no longer accepting those arguments
  and by using the more recent `loopy--instr-let-const*` and
  `loopy--instr-let-var*`.

- Remove the assumption that the `list` argument of
  `loopy--only-valid-keywords-p` is a proper plist.
  - Remove the singly used function `loopy--extract-keywords`.

- Modify `loopy--defiteration` to always define the variable `opts` when
  keywords are used, to always check keyword arguments when keywords are used,
  to set the internal variable `required-vals` to 0 when it is nil,
  and to set `other-vals` to nil when it is 0 or a list only containing 0.

- Begin updating tests.

- Org documentation should not need an update.