### PR TITLE
Use custom setters for GV expansion and simplify produced code.

### DIFF
--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -2348,13 +2348,8 @@ will only overwrite values, not truncate or grow the array.
 #+attr_texinfo: :tag Warning
 #+begin_quote
 Unfortunately, not all kinds of recursive destructuring work on references.
-This is a limitation of how generic setters are implemented, and not all
-limitations are specific to ~loopy~.
 
 Currently:
-- The variable after =&rest= in arrays cannot be recursive.
-- The variables after =&map= cannot be recursive due to the current
-  implementation of =map.el= upstream.
 - =&optional= variables are not supported
 - =SUPPLIED= variables are not supported for =&key= and =&map=.
 - Non-nil default values for =&optional=, =&key=, and =&map= are not supported.

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -705,7 +705,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting something like the below example might not do what you expect, as @samp{i}
 is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,orgcd9d132
+@float Listing,org4aaf858
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -887,7 +887,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,orgf148300
+@float Listing,org57f8a2b
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -902,7 +902,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,orgff97ac8
+@float Listing,orgcb879ea
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -2535,16 +2535,9 @@ will only overwrite values, not truncate or grow the array.
 
 @quotation Warning
 Unfortunately, not all kinds of recursive destructuring work on references.
-This is a limitation of how generic setters are implemented, and not all
-limitations are specific to @code{loopy}.
 
 Currently:
 @itemize
-@item
-The variable after @samp{&rest} in arrays cannot be recursive.
-@item
-The variables after @samp{&map} cannot be recursive due to the current
-implementation of @samp{map.el} upstream.
 @item
 @samp{&optional} variables are not supported
 @item
@@ -4685,7 +4678,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-aliases}.
 
-@float Listing,org7411b6a
+@float Listing,org024caac
 @lisp
 ;; => ((1 2 3) (-3 -2 -1) (0))
 (loopy-iter (arg accum-opt positives negatives other)


### PR DESCRIPTION
- Use custom setters for GV expansion.  Create `loopy--seq-drop` and `loopy--destructure-map-elt`.  For `loopy--seq-drop`, use `loopy--destructure-seq-replace`.

- Try to avoid creating intermediate subsequences when destructuring arrays as generalized variables.  We know ahead of time where subsequences begin and how arrays are treated as maps, so use that to compute indices ahead of time when we can.
  - Create the macros `loopy--destructure-gv-array-rest-simplifier`, `loopy--destructure-gv-array-map-simplifier`, and `loopy--destructure-gv-array-elt-simplifier`.

- Fix some tests.
  - Don't try to modify literals in the array tests.

- Comment the motivations and reasoning about this code.

- Add more tests.

See issue #183 and this PR #212.