### PR TITLE
Create loop commands for generic (`seq.el`) sequences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ This document describes the user-facing changes to Loopy.
 
 ## Unreleased
 
+### Commands for Generic (`seq.el`) Sequences
+
+Loopy can now loop through generic sequences implemented by the library `seq.el`
+([#215], [#150], [#136]).  Currently, this is done naively via the functions
+`seq-elt` and `seq-length`.  Because a package might implement a generic
+sequence using one of the built-in sequence types (lists and arrays), no attempt
+is made to optimize behavior for particular kinds of sequences.  As a
+comparison, the `sequence` command gives special consideration to lists in some
+circumstances.
+
+Because these commands use `seq-length`, they do not work with infinite
+sequences.  For that, consider using the `stream` command.
+
+The new commands are `seq` and `seq-ref`, which were previously aliases of
+`sequence` and `sequence-ref`, respectively ([#126, #206]).  This change should
+not cause an error, but the expanded code might be slower depending on the type
+of the sequence.
+
+`sequence-index`, which keeps the alias `seq-index`, has been changed to use
+`seq-length` instead of `length`.  This command is simple enough that no special
+version is needed for generic sequences.
+
 ### Breaking Changes
 
 - Conflicting starting values for accumulation variables, such as from using
@@ -34,13 +56,9 @@ This document describes the user-facing changes to Loopy.
   - `set-prev`: `prev`, `prev-expr`
   - `sequence`: `elements`
   - `sequence-index`: `sequencei`, `seqi`, `listi`, `arrayi`, `stringi`
-  - `sequence-ref`: `seqf`, `sequencef`, `sequencingf`, `elements-ref`
-
-- Make `sequence` the default name and `seq` an alias ([#126, #206]).
-
-- Make `sequence-ref` the default name and `seq-ref` an alias ([#126, #206]).
-
-- Make `sequence-index` the default name and `seq-index` an alias ([#126, #206]).
+  - `sequence-ref`: `sequencef`, `sequencingf`,
+    `elements-ref`
+  - `seq-ref`: `seqf` , `seqingf`
 
 - Review when the values of keyword arguments are taken and used ([#210]):
   - Make the `close` keyword argument of the `iter` command able to be evaluated
@@ -59,11 +77,11 @@ This document describes the user-facing changes to Loopy.
   showed that this is consistently faster than the old method.
 
 - Recursive destructuring for generalized variables (`setf`-able places), such
-  as in the below example, now work as expected, due to a combination of custom
-  GV setters and simplifying the produced code in some cases ([#212], [#213],
-  [#184]).  This can sometimes result in redundant operations when setting the
-  value of the generalized variable, but we've made an effort to reduce the
-  number of occurences in the obvious cases.
+  as in the below example, should now work as expected, due to a combination of
+  custom GV setters and simplifying the produced code in some cases ([#212],
+  [#213], [#184]).  This can sometimes result in redundant operations when
+  setting the value of the generalized variable, but we've made an effort to
+  reduce the number of occurences in the obvious cases.
 
   ```elisp
   ;; => [1 2 3 4 0 0 16]
@@ -80,6 +98,8 @@ This document describes the user-facing changes to Loopy.
   values than it actually contains ([#217]).
 
 [#126]: https://github.com/okamsn/loopy/issues/126
+[#136]: https://github.com/okamsn/loopy/issues/136
+[#150]: https://github.com/okamsn/loopy/issues/150
 [#168]: https://github.com/okamsn/loopy/issues/168
 [#169]: https://github.com/okamsn/loopy/issues/169
 [#179]: https://github.com/okamsn/loopy/issues/179
@@ -93,6 +113,7 @@ This document describes the user-facing changes to Loopy.
 [#211]: https://github.com/okamsn/loopy/pull/211
 [#212]: https://github.com/okamsn/loopy/pull/212
 [#213]: https://github.com/okamsn/loopy/pull/213
+[#215]: https://github.com/okamsn/loopy/pull/215
 [#217]: https://github.com/okamsn/loopy/pull/217
 
 ## 0.13.0

--- a/README.org
+++ b/README.org
@@ -39,6 +39,9 @@ please let me know.
      list of built-in aliases in the future.  They can still be added to the
      list of known aliases using ~loopy-defalias~.  See the changelog for more
      information.
+   - =seq= and =seq-ref= now work on generic sequences and are separate commands
+     from =sequence= and =sequence-ref=.  =sequence-index= now uses
+     ~seq-length~.
    - Improved consistency of some keyword arguments:
      - The =:unique= keyword argument of the =map= and =map-ref= commands can now
        be evaluable at run time.

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -2073,11 +2073,9 @@ source sequences.
            (collect (list key val)))
   #+end_src
 
-#+findex: seq
 #+findex: sequence
-#+findex: seqing
 #+findex: sequencing
-- =(sequence|seq VAR EXPR [EXPRS] &key KEYS)= :: Loop through the sequence
+- =(sequence VAR EXPR [EXPRS] &key KEYS)= :: Loop through the sequence
   =EXPR=, binding =VAR= to the elements of the sequence (a list or an array).
   Because it is more generic, =sequence= is somewhat less efficient than the
   =list= and =array= commands.
@@ -2087,10 +2085,10 @@ source sequences.
   For more on sequences, see [[info:elisp#Sequences Arrays Vectors]].  This command
   works with the basic sequences understood by the Emacs Lisp functions ~length~
   and ~elt~.  It does not work with the generic sequences understood by the
-  library =seq.el=.
+  library =seq.el=.  For those, use the =seq= command.
   #+end_quote
 
-  This command also has the aliases =sequencing= and =seqing=.
+  This command also has the alias =sequencing=.
 
   =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
   =downto=, =above=, =below=, =by=, =test=, and =index=.  =index= names the
@@ -2138,6 +2136,48 @@ source sequences.
     (loopy (sequence i [1 2] '(3 4) :by 2)
            (collect i))
   #+END_SRC
+
+#+findex: seq
+#+findex: seqing
+- =(seq VAR EXPR [EXPRS] &key KEYS)= :: For generic a sequence implementing the
+  features of the library =seq.el=, loop through the generic sequence =EXPR=,
+  binding =VAR= to the elements of the sequence.  Because it is more generic,
+  =seq= can be slower than the =sequence= command, which in turn is somewhat
+  less efficient than the =list= and =array= commands.
+
+  If multiple generic sequences are given, then these keyword arguments apply to
+  the resulting generic sequence of distributed elements.
+
+  =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+  =downto=, =above=, =below=, =by=, =test=, and =index=.  =index= names the
+  variable used to store the index being accessed.  For the others, see the
+  =numbers= command.
+
+  This command also has the alias =seqing=.
+
+  The =seq= command naively loops through the generic sequence using ~seq-elt~
+  and ~seq-length~.  Because other packages might implement custom sequences
+  using lists, no special consideration is made for optimizing the =seq= command
+  when given a list.
+
+  Because the =seq= command currently uses the function ~seq-length~ to detect
+  when to leave the loop, it does not work with infinite sequences.  For
+  infinite sequences, consider using the =stream= command.
+
+  #+begin_src emacs-lisp
+    ;; => (0 2 4)
+    (loopy (seq i [0 1 2 3 4 5] :by 2)
+           (collect i))
+
+    ;; => (5 3 1)
+    (loopy (seq i '(0 1 2 3 4 5 6)
+                :downfrom 5 :by 2 :to 1)
+           (collect i))
+
+    ;; => ((1 3) (2 3))
+    (loopy (seq i [1 2] '(3 4) :by 2)
+           (collect i))
+  #+end_src
 
 #+findex: stream
 #+findex: streaming
@@ -2262,7 +2302,8 @@ iterate.
   - =array-index=, =arraying-index=
   - =list-index=, =listing-index=
   - =string-index=, =stringing-index=
-  - =sequencing-index=, =seq-index=, =seqing-index=
+  - =sequencing-index=
+  -  =seq-index=, =seqing-index=
 
 
   =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
@@ -2486,13 +2527,10 @@ the accessed index during the loop.
 
 #+findex: sequence-ref
 #+findex: sequencing-ref
-#+findex: seq-ref
-#+findex: seqing-ref
-- =(sequence-ref|seq-ref VAR EXPR &key KEYS)= :: Loop
-  through the elements of the sequence =EXPR=, binding =VAR= as a
-  ~setf~-able place.
+- =(sequence-ref VAR EXPR &key KEYS)= :: Loop through the elements of the
+  sequence =EXPR= (an array or list), binding =VAR= as a ~setf~-able place.
 
-  This command also has the aliases =sequencing-ref= and =seqing-ref=.
+  This command also has the aliases =sequencing-ref=.
 
   =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
   =downto=, =above=, =below=, =by=, =test=, and =index=.  =index= names the
@@ -2515,6 +2553,53 @@ the accessed index during the loop.
     ;; => "0123456a8a"
     (loopy (with (my-str (copy-sequence "0123456789")))
            (sequence-ref i my-str :downto 6 :by 2 )
+           (do (setf i ?a))
+           (finally-return my-str))
+  #+END_SRC
+
+#+findex: seq-ref
+#+findex: seqing-ref
+- =(seq-ref VAR EXPR &key KEYS)= :: Loop through the elements of the generic
+  sequence =EXPR=, via the features of the library =seq.el=, binding =VAR= as a
+  ~setf~-able place.
+
+  #+attr_texinfo: :tag Note
+  #+begin_quote
+    Not all generic sequences are mutable, so not all generic sequences work as
+    a ~setf~-able place.
+  #+end_quote
+
+  =KEYS= is one or several of =from=, =upfrom=, =downfrom=, =to=, =upto=,
+  =downto=, =above=, =below=, =by=, =test=, and =index=.  =index= names the
+  variable used to store the index being accessed.  For others, see the
+  =numbers= command.
+
+  This command also has the alias =seqing-ref=.
+
+  The =seq-ref= command naively loops through the generic sequence using
+  ~seq-elt~ and ~seq-length~.  Because other packages might implement custom
+  sequences using lists, no special consideration is made for optimizing the
+  =seq-ref= command when given a list.
+
+  Because the =seq-ref= command currently uses the function ~seq-length~ to
+  detect when to leave the loop, it does not work with infinite sequences.
+
+  #+BEGIN_SRC emacs-lisp
+    ;; => (7 7 7 7)
+    (loopy (with (my-seq (list 1 2 3 4)))
+           (seq-ref i my-seq)
+           (do (setf i 7))
+           (finally-return my-seq))
+
+    ;; => (0 cat 2 cat 4 cat 6 cat 8 cat)
+    (loopy (with (my-list (list 0 1 2 3 4 5 6 7 8 9)))
+           (seq-ref i my-list :from 1 :by 2 )
+           (do (setf i 'cat))
+           (finally-return my-list))
+
+    ;; => "0123456a8a"
+    (loopy (with (my-str (copy-sequence "0123456789")))
+           (seq-ref i my-str :downto 6 :by 2 )
            (do (setf i ?a))
            (finally-return my-str))
   #+END_SRC
@@ -4504,12 +4589,14 @@ create a list if more than one return value is given.
       - =arraying-index=
       - =listing-index=
       - =sequencing-index=
+      - =seqing-index=
       - =stringing-index=
     - Sequence Reference Iteration Command Names:
       - =arraying-ref=
       - =listing-ref=
       - =mapping-ref=
       - =sequencing-ref=
+      - =seqing-ref=
       - =stringing-ref=
   - Accumulation Commands:
     - =accumulating=

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -705,7 +705,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting something like the below example might not do what you expect, as @samp{i}
 is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,org4aaf858
+@float Listing,orgbe3a744
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -887,7 +887,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,org57f8a2b
+@float Listing,org0b98f72
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -902,7 +902,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,orgcb879ea
+@float Listing,orgec2e7cb
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -2250,12 +2250,10 @@ Again, this can be disabled by setting @samp{unique} to nil.
 @end lisp
 @end table
 
-@findex seq
 @findex sequence
-@findex seqing
 @findex sequencing
 @table @asis
-@item @samp{(sequence|seq VAR EXPR [EXPRS] &key KEYS)}
+@item @samp{(sequence VAR EXPR [EXPRS] &key KEYS)}
 Loop through the sequence
 @samp{EXPR}, binding @samp{VAR} to the elements of the sequence (a list or an array).
 Because it is more generic, @samp{sequence} is somewhat less efficient than the
@@ -2265,11 +2263,11 @@ Because it is more generic, @samp{sequence} is somewhat less efficient than the
 For more on sequences, see @ref{Sequences Arrays Vectors,,,elisp,}.  This command
 works with the basic sequences understood by the Emacs Lisp functions @code{length}
 and @code{elt}.  It does not work with the generic sequences understood by the
-library @samp{seq.el}.
+library @samp{seq.el}.  For those, use the @samp{seq} command.
 
 @end quotation
 
-This command also has the aliases @samp{sequencing} and @samp{seqing}.
+This command also has the alias @samp{sequencing}.
 
 @samp{KEYS} is one or several of @samp{from}, @samp{upfrom}, @samp{downfrom}, @samp{to}, @samp{upto},
 @samp{downto}, @samp{above}, @samp{below}, @samp{by}, @samp{test}, and @samp{index}.  @samp{index} names the
@@ -2315,6 +2313,51 @@ resulting sequence of distributed elements.
 
 ;; => ((1 3) (2 3))
 (loopy (sequence i [1 2] '(3 4) :by 2)
+       (collect i))
+@end lisp
+@end table
+
+@findex seq
+@findex seqing
+@table @asis
+@item @samp{(seq VAR EXPR [EXPRS] &key KEYS)}
+For generic a sequence implementing the
+features of the library @samp{seq.el}, loop through the generic sequence @samp{EXPR},
+binding @samp{VAR} to the elements of the sequence.  Because it is more generic,
+@samp{seq} can be slower than the @samp{sequence} command, which in turn is somewhat
+less efficient than the @samp{list} and @samp{array} commands.
+
+If multiple generic sequences are given, then these keyword arguments apply to
+the resulting generic sequence of distributed elements.
+
+@samp{KEYS} is one or several of @samp{from}, @samp{upfrom}, @samp{downfrom}, @samp{to}, @samp{upto},
+@samp{downto}, @samp{above}, @samp{below}, @samp{by}, @samp{test}, and @samp{index}.  @samp{index} names the
+variable used to store the index being accessed.  For the others, see the
+@samp{numbers} command.
+
+This command also has the alias @samp{seqing}.
+
+The @samp{seq} command naively loops through the generic sequence using @code{seq-elt}
+and @code{seq-length}.  Because other packages might implement custom sequences
+using lists, no special consideration is made for optimizing the @samp{seq} command
+when given a list.
+
+Because the @samp{seq} command currently uses the function @code{seq-length} to detect
+when to leave the loop, it does not work with infinite sequences.  For
+infinite sequences, consider using the @samp{stream} command.
+
+@lisp
+;; => (0 2 4)
+(loopy (seq i [0 1 2 3 4 5] :by 2)
+       (collect i))
+
+;; => (5 3 1)
+(loopy (seq i '(0 1 2 3 4 5 6)
+            :downfrom 5 :by 2 :to 1)
+       (collect i))
+
+;; => ((1 3) (2 3))
+(loopy (seq i [1 2] '(3 4) :by 2)
        (collect i))
 @end lisp
 @end table
@@ -2451,7 +2494,9 @@ type-specific versions.  This command also has the following aliases:
 @item
 @samp{string-index}, @samp{stringing-index}
 @item
-@samp{sequencing-index}, @samp{seq-index}, @samp{seqing-index}
+@samp{sequencing-index}
+@item
+@samp{seq-index}, @samp{seqing-index}
 @end itemize
 @end table
 
@@ -2688,15 +2733,12 @@ duplicate's value.
 
 @findex sequence-ref
 @findex sequencing-ref
-@findex seq-ref
-@findex seqing-ref
 @table @asis
-@item @samp{(sequence-ref|seq-ref VAR EXPR &key KEYS)}
-Loop
-through the elements of the sequence @samp{EXPR}, binding @samp{VAR} as a
-@code{setf}-able place.
+@item @samp{(sequence-ref VAR EXPR &key KEYS)}
+Loop through the elements of the
+sequence @samp{EXPR} (an array or list), binding @samp{VAR} as a @code{setf}-able place.
 
-This command also has the aliases @samp{sequencing-ref} and @samp{seqing-ref}.
+This command also has the aliases @samp{sequencing-ref}.
 
 @samp{KEYS} is one or several of @samp{from}, @samp{upfrom}, @samp{downfrom}, @samp{to}, @samp{upto},
 @samp{downto}, @samp{above}, @samp{below}, @samp{by}, @samp{test}, and @samp{index}.  @samp{index} names the
@@ -2719,6 +2761,56 @@ variable used to store the index being accessed.  For others, see the
 ;; => "0123456a8a"
 (loopy (with (my-str (copy-sequence "0123456789")))
        (sequence-ref i my-str :downto 6 :by 2 )
+       (do (setf i ?a))
+       (finally-return my-str))
+@end lisp
+@end table
+
+@findex seq-ref
+@findex seqing-ref
+@table @asis
+@item @samp{(seq-ref VAR EXPR &key KEYS)}
+Loop through the elements of the generic
+sequence @samp{EXPR}, via the features of the library @samp{seq.el}, binding @samp{VAR} as a
+@code{setf}-able place.
+
+@quotation Note
+Not all generic sequences are mutable, so not all generic sequences work as
+a @code{setf}-able place.
+
+@end quotation
+
+@samp{KEYS} is one or several of @samp{from}, @samp{upfrom}, @samp{downfrom}, @samp{to}, @samp{upto},
+@samp{downto}, @samp{above}, @samp{below}, @samp{by}, @samp{test}, and @samp{index}.  @samp{index} names the
+variable used to store the index being accessed.  For others, see the
+@samp{numbers} command.
+
+This command also has the alias @samp{seqing-ref}.
+
+The @samp{seq-ref} command naively loops through the generic sequence using
+@code{seq-elt} and @code{seq-length}.  Because other packages might implement custom
+sequences using lists, no special consideration is made for optimizing the
+@samp{seq-ref} command when given a list.
+
+Because the @samp{seq-ref} command currently uses the function @code{seq-length} to
+detect when to leave the loop, it does not work with infinite sequences.
+
+@lisp
+;; => (7 7 7 7)
+(loopy (with (my-seq (list 1 2 3 4)))
+       (seq-ref i my-seq)
+       (do (setf i 7))
+       (finally-return my-seq))
+
+;; => (0 cat 2 cat 4 cat 6 cat 8 cat)
+(loopy (with (my-list (list 0 1 2 3 4 5 6 7 8 9)))
+       (seq-ref i my-list :from 1 :by 2 )
+       (do (setf i 'cat))
+       (finally-return my-list))
+
+;; => "0123456a8a"
+(loopy (with (my-str (copy-sequence "0123456789")))
+       (seq-ref i my-str :downto 6 :by 2 )
        (do (setf i ?a))
        (finally-return my-str))
 @end lisp
@@ -4678,7 +4770,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-aliases}.
 
-@float Listing,org024caac
+@float Listing,orgd6b91a9
 @lisp
 ;; => ((1 2 3) (-3 -2 -1) (0))
 (loopy-iter (arg accum-opt positives negatives other)
@@ -4928,6 +5020,8 @@ Sequence Index Iteration Command Names:
 @item
 @samp{sequencing-index}
 @item
+@samp{seqing-index}
+@item
 @samp{stringing-index}
 @end itemize
 @item
@@ -4941,6 +5035,8 @@ Sequence Reference Iteration Command Names:
 @samp{mapping-ref}
 @item
 @samp{sequencing-ref}
+@item
+@samp{seqing-ref}
 @item
 @samp{stringing-ref}
 @end itemize

--- a/loopy-iter.el
+++ b/loopy-iter.el
@@ -143,6 +143,7 @@ Without these keywords, one must use one of the names given in
     returning-from
     seqing
     seqing-index
+    seqing-ref
     sequencing
     sequencing-index
     sequencing-ref

--- a/loopy-vars.el
+++ b/loopy-vars.el
@@ -89,7 +89,8 @@ Definition must exist.  Neither argument need be quoted."
     (set-prev prev prev-expr)
     (sequence elements)
     (sequence-index sequencei seqi listi arrayi stringi)
-    (sequence-ref seqf sequencef sequencingf elements-ref))
+    (seq-ref seqf seqingf)
+    (sequence-ref sequencef sequencingf elements-ref))
   "Aliases to be removed from the documentation.")
 
 ;;;###autoload
@@ -142,13 +143,15 @@ Definition must exist.  Neither argument need be quoted."
     (set             . (setting))
     (set-accum       . (setting-accum))
     (set-prev        . (setting-prev prev-set))
-    (sequence        . (sequencing seq seqing))
+    (sequence        . (sequencing))
+    (seq             . (seqing))
     (sequence-index       . ( seq-index seqing-index
                               sequencing-index
                               list-index listing-index
                               array-index arraying-index
                               string-index stringing-index))
-    (sequence-ref    . (seqing-ref seq-ref sequencing-ref))
+    (seq-ref         . (seqing-ref))
+    (sequence-ref    . (sequencing-ref))
     (skip            . (skipping continue continuing))
     (skip-from       . (skipping-from continue-from continuing-from))
     (stream          . (streaming))
@@ -213,9 +216,11 @@ true names and lists of aliases.
     (reduce       . loopy--parse-reduce-command)
     (return       . loopy--parse-return-command)
     (return-from  . loopy--parse-return-from-command)
-    (sequence       . loopy--parse-seq-command)
-    (sequence-index . loopy--parse-seq-index-command)
-    (sequence-ref   . loopy--parse-seq-ref-command)
+    (seq          . loopy--parse-seq-command)
+    (sequence     . loopy--parse-sequence-command)
+    (sequence-index . loopy--parse-sequence-index-command)
+    (seq-ref      . loopy--parse-seq-ref-command)
+    (sequence-ref . loopy--parse-sequence-ref-command)
     (set          . loopy--parse-set-command)
     (set-prev     . loopy--parse-set-prev-command)
     (skip         . loopy--parse-skip-command)

--- a/loopy.el
+++ b/loopy.el
@@ -6,7 +6,7 @@
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
 ;; Version: 0.13.0
-;; Package-Requires: ((emacs "27.1") (map "3.3.1") (seq "2.22") (compat "29.1.3") (stream "2.3.0"))
+;; Package-Requires: ((emacs "27.1") (map "3.3.1") (seq "2.22") (compat "29.1.3") (stream "2.4.0"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs Edebug
 

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -25,6 +25,8 @@
 (require 'subr-x)
 (require 'package)
 (require 'compat)
+(require 'seq)
+(require 'stream)
 (require 'map)
 (require 'ert)
 (require 'generator)
@@ -231,6 +233,162 @@ SYMS-STR are the string names of symbols from `loopy-iter-bare-commands'."
                                           for iter in syms-str
                                           collect (format "(%s . %s)" true iter))
                                  "\n")))))
+
+
+;;; Custom sequence for testing
+
+(cl-defstruct loopy--test-custom-seq
+  "Custom sequence for testing generic sequences."
+  (value)
+  (next))
+
+(cl-defmethod seqp ((_seq loopy--test-custom-seq))
+  t)
+
+(ert-deftest custom-seq-seqp ()
+  (should (seqp (make-loopy--test-custom-seq :value 0 :next nil))))
+
+(cl-defmethod seq-do (func (seq loopy--test-custom-seq))
+  (cl-assert (loopy--test-custom-seq-p seq)
+             "Non-custom-seq passed to `seq-do' for custom seqs")
+  (while seq
+    (funcall func (loopy--test-custom-seq-value seq))
+    (setq seq (loopy--test-custom-seq-next seq))))
+
+(ert-deftest custom-seq-do ()
+  (should (equal '(2 1 0)
+                 (let ((res))
+                   (seq-do (lambda (x) (push x res))
+                           (make-loopy--test-custom-seq
+                            :value 0
+                            :next (make-loopy--test-custom-seq
+                                   :value 1
+                                   :next (make-loopy--test-custom-seq
+                                          :value 2
+                                          :next nil))))
+                   res))))
+
+(ert-deftest custom-seq-do-not-affect-streams ()
+  "We're seeing some odd behavior in the `substream' tests after
+writing a `seq-do' method for the custom seq."
+  (should (equal '(2 1 0)
+                 (let ((res))
+                   (seq-do (lambda (x) (push x res))
+                           (stream (vector 0 1 2)))
+                   res))))
+
+(cl-defmethod seq-into-sequence ((seq loopy--test-custom-seq))
+  (let ((res nil))
+    (seq-do (lambda (elt) (push elt res))
+            seq)
+    (nreverse res)))
+
+(ert-deftest custom-seq-into-sequence ()
+  (should (equal '(0 1 2)
+                 (seq-into-sequence (make-loopy--test-custom-seq
+                                     :value 0
+                                     :next (make-loopy--test-custom-seq
+                                            :value 1
+                                            :next (make-loopy--test-custom-seq
+                                                   :value 2
+                                                   :next nil)))))))
+
+(cl-defmethod seq-into (seq (_type (eql loopy--test-custom-seq)))
+  (let ((res)
+        (this))
+    (seq-doseq (elt seq)
+      (if (not res)
+          (setq res (make-loopy--test-custom-seq :value elt :next nil)
+                this res)
+        (let ((new (make-loopy--test-custom-seq :value elt :next nil)))
+          (setf (loopy--test-custom-seq-next this) new
+                this new))))
+    res))
+
+(ert-deftest custom-seq-into ()
+  (should (equal (seq-into '(0 1 2) 'loopy--test-custom-seq)
+                 (make-loopy--test-custom-seq
+                  :value 0
+                  :next (make-loopy--test-custom-seq
+                         :value 1
+                         :next (make-loopy--test-custom-seq
+                                :value 2
+                                :next nil))))))
+
+(cl-defmethod seq-elt ((seq loopy--test-custom-seq) idx)
+  (cl-block loopy--test-custom-seq-elt
+    (seq-do-indexed (lambda (elt idx2)
+                      (when (= idx idx2)
+                        (cl-return-from loopy--test-custom-seq-elt elt)))
+                    seq)
+    (signal 'args-out-of-range (list seq idx))))
+
+(ert-deftest custom-seq-elt ()
+  (should (= 1 (seq-elt (seq-into '(0 1 2 3 4) 'loopy--test-custom-seq) 1))))
+
+(cl-defmethod seq-length ((seq loopy--test-custom-seq))
+  (let ((res 0))
+    (seq-do (lambda (_) (setq res (1+ res)))
+            seq)
+    res))
+
+(ert-deftest custom-seq-length ()
+  (should (= 5 (seq-length (seq-into '(0 1 2 3 4) 'loopy--test-custom-seq)))))
+
+(cl-defmethod seq-copy ((seq loopy--test-custom-seq))
+  (seq-into seq 'loopy--test-custom-seq))
+
+(ert-deftest custom-seq-copy ()
+  (should-not (let* ((seq1 (make-loopy--test-custom-seq :value 1 :next nil))
+                     (seq2 (seq-copy seq1)))
+                (setf (loopy--test-custom-seq-value seq1) 99)
+                (equal seq1 seq2))))
+
+(cl-defmethod seq-subseq ((seq loopy--test-custom-seq) start &optional end)
+  "Inefficient but good enough for testing."
+  (seq-into (seq-subseq (seq-into-sequence seq)
+                        start end)
+            'loopy--test-custom-seq))
+
+(ert-deftest custom-seq-subseq ()
+  (should (equal (make-loopy--test-custom-seq
+                  :value 0
+                  :next (make-loopy--test-custom-seq
+                         :value 1
+                         :next (make-loopy--test-custom-seq
+                                :value 2
+                                :next nil)))
+                 (seq-subseq  (seq-into '(10 12 0 1 2 3 4) 'loopy--test-custom-seq)
+                              2 5))))
+
+(cl-defmethod (setf seq-elt) (store (sequence loopy--test-custom-seq) n)
+  (let ((idx2 0))
+    (while (/= n idx2)
+      (let ((next (loopy--test-custom-seq-next sequence)))
+        (if (null next)
+            (signal 'args-out-of-range (list sequence n))
+          (setq sequence next)
+          (cl-incf idx2))))
+    (setf (loopy--test-custom-seq-value sequence) store))
+  store)
+
+(ert-deftest custom-seq-setf-seq-elt ()
+  (should (equal (make-loopy--test-custom-seq
+                  :value 0
+                  :next (make-loopy--test-custom-seq
+                         :value 99
+                         :next (make-loopy--test-custom-seq
+                                :value 2
+                                :next nil)))
+                 (let ((seq (make-loopy--test-custom-seq
+                             :value 0
+                             :next (make-loopy--test-custom-seq
+                                    :value 1
+                                    :next (make-loopy--test-custom-seq
+                                           :value 2
+                                           :next nil)))))
+                   (setf (seq-elt seq 1) 99)
+                   seq))))
 
 ;;; Macro arguments
 ;;;; Named (loop Name)
@@ -2269,7 +2427,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((collect . collecting)
               (cycle . cycling)))
 
-;;;;; Seq
+;;;;; Sequence
 (loopy-deftest sequence
   :result t
   :body ((_cmd l '(97 98 99 100 101))
@@ -2280,24 +2438,37 @@ Using numbers directly will use less variables and more efficient code."
              (return nil))
          (finally-return t))
   :repeat _cmd
-  :loopy ((_cmd . (seq sequence seqing sequencing elements)))
-  :iter-keyword ((_cmd . (seq sequence seqing sequencing elements))
+  :loopy ((_cmd . (sequence sequencing elements)))
+  :iter-keyword ((_cmd . (sequence sequencing elements))
                  (return . return))
-  :iter-bare ((seq . (seqing sequencing))
+  :iter-bare ((sequence . (sequencing))
               (return . returning)))
 
-(loopy-deftest seq-destructuring
-  :doc "Check that `seq' implements destructuring, not the destructuring itself."
+(loopy-deftest sequence-not-seq
+  :doc "Check that `sequence' does not correctly work on `seq'.
+If it does, we confused them somewhere in the setup code.  Custom types
+are records, which are sequences, so they still work in that way."
+  :result '(loopy--test-custom-seq 1 nil)
+  :body ((with (my-seq (seq-into '(1) 'loopy--test-custom-seq)))
+         (sequence i my-seq)
+         (collect i))
+  :loopy t
+  :iter-keyword (sequence collect)
+  :iter-bare ((sequence . sequencing)
+              (collect . collecting)))
+
+(loopy-deftest sequence-destructuring
+  :doc "Check that `sequence' implements destructuring, not the destructuring itself."
   :result '(97 98)
   :multi-body t
-  :body [((seq (a . b) [(97 . 98)]) (finally-return a b))
-         ((seq [a b] '([97 98])) (finally-return a b))
-         ((seq [a b] ["ab"]) (finally-return a b))]
+  :body [((sequence (a . b) [(97 . 98)]) (finally-return a b))
+         ((sequence [a b] '([97 98])) (finally-return a b))
+         ((sequence [a b] ["ab"]) (finally-return a b))]
   :loopy t
-  :iter-keyword (seq)
-  :iter-bare ((seq . sequencing)))
+  :iter-keyword (sequence)
+  :iter-bare ((sequence . sequencing)))
 
-(loopy-deftest seq-:by
+(loopy-deftest sequence-:by
   :result '(0 2 4 6 8 10)
   :multi-body t
   :body [((sequence i (list 0 1 2 3 4 5 6 7 8 9 10) :by 2)
@@ -2309,7 +2480,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:by-just-once
+(loopy-deftest sequence-:by-just-once
   :doc "`:by' should only be evaluated once."
   :result '(1 3 5)
   :multi-body t
@@ -2331,7 +2502,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-end-just-once
+(loopy-deftest sequence-end-just-once
   :doc "`:by' should only be evaluated once."
   :result '(0 1 2)
   :multi-body t
@@ -2374,7 +2545,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:index
+(loopy-deftest sequence-:index
   :result '((0 . 4) (1 . 3) (2 . 2) (3 . 1) (4 . 0))
   :multi-body t
   :body [((sequence i [4 3 2 1 0] :index cat)
@@ -2386,7 +2557,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:from-:downto-:by
+(loopy-deftest sequence-:from-:downto-:by
   :result '(8 6 4 2)
   :body ((sequence i [0 1 2 3 4 5 6 7 8 9 10]
                    :from 8 :downto 1 :by 2)
@@ -2396,7 +2567,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:upto
+(loopy-deftest sequence-:upto
   :result '(0 1 2 3 4 5 6 7)
   :body  ((sequence i [0 1 2 3 4 5 6 7 8 9 10] :upto 7)
           (collect i))
@@ -2405,7 +2576,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:to
+(loopy-deftest sequence-:to
   :result '(0 1 2 3 4 5 6 7)
   :body  ((sequence i [0 1 2 3 4 5 6 7 8 9 10] :to 7)
           (collect i))
@@ -2414,7 +2585,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:downto
+(loopy-deftest sequence-:downto
   :result '(10 9 8 7 6 5 4 3)
   :body  ((sequence i [0 1 2 3 4 5 6 7 8 9 10] :downto 3)
           (collect i))
@@ -2423,7 +2594,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:above
+(loopy-deftest sequence-:above
   :result '(10 9 8)
   :body  ((sequence i [0 1 2 3 4 5 6 7 8 9 10] :above 7)
           (collect i))
@@ -2432,7 +2603,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:below
+(loopy-deftest sequence-:below
   :result '(0 1 2)
   :body  ((sequence i [0 1 2 3 4 5 6 7 8 9 10] :below 3)
           (collect i))
@@ -2441,7 +2612,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:downfrom
+(loopy-deftest sequence-:downfrom
   :result '(5 4 3 2 1 0)
   :body ((sequence i [0 1 2 3 4 5] :downfrom 5)
          (collect i))
@@ -2450,7 +2621,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-:upfrom
+(loopy-deftest sequence-:upfrom
   :result '(2 3 4 5)
   :body ((sequence i [0 1 2 3 4 5] :upfrom 2)
          (collect i))
@@ -2459,7 +2630,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-multi-seq
+(loopy-deftest sequence-multi-sequence
   :result '((1 3) (1 4) (2 3) (2 4))
   :body ((sequence i [1 2] '(3 4))
          (collect i))
@@ -2468,7 +2639,7 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence . sequencing)
               (collect . collecting)))
 
-(loopy-deftest seq-multi-seq-:by
+(loopy-deftest sequence-multi-sequence-:by
   :result '((1 3)  (2 3))
   :body ((sequence i [1 2] '(3 4) :by 2)
          (collect i))
@@ -2522,6 +2693,299 @@ Using numbers directly will use less variables and more efficient code."
   :loopy t
   :iter-keyword (sequence collect)
   :iter-bare ((sequence . sequencing)
+              (collect . collecting)))
+
+;;;;; Seq
+(loopy-deftest seq
+  :result t
+  :body ((_cmd l '(97 98 99 100 101))
+         (_cmd a [97 98 99 100 101])
+         (_cmd s "abcde")
+         (_cmd c (seq-into '(97 98 99 100 101)
+                           'loopy--test-custom-seq))
+         (if (not (and (/= l a)
+                       (/= a s)
+                       (/= s c)))
+             (return nil))
+         (finally-return t))
+  :repeat _cmd
+  :loopy ((_cmd . (seq seqing)))
+  :iter-keyword ((_cmd . (seq seqing))
+                 (return . return))
+  :iter-bare ((_cmd . (seqing))
+              (return . returning)))
+
+(loopy-deftest seq-destructuring
+  :doc "Check that `seq' implements destructuring, not the destructuring itself."
+  :result '(97 98)
+  :multi-body t
+  :body [((seq (a . b) [(97 . 98)]) (finally-return a b))
+         ((seq [a b] '([97 98])) (finally-return a b))
+         ((seq [a b] ["ab"]) (finally-return a b))
+         ((seq [a b] (seq-into '("ab") 'loopy--test-custom-seq)) (finally-return a b))]
+  :loopy t
+  :iter-keyword (seq)
+  :iter-bare ((seq . seqing)))
+
+(loopy-deftest seq-:by
+  :result '(0 2 4 6 8 10)
+  :multi-body t
+  :body [((seq i (list 0 1 2 3 4 5 6 7 8 9 10) :by 2)
+          (collect i))
+         ((seq i [0 1 2 3 4 5 6 7 8 9 10] :by 2)
+          (collect i))
+         ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :by 2)
+          (collect i))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:by-just-once
+  :doc "`:by' should only be evaluated once."
+  :result '(1 3 5)
+  :multi-body t
+  :body [((with (times 0))
+          (seq i (vector 1 2 3 4 5 6) :by (progn
+                                            (cl-assert (= times 0))
+                                            (cl-incf times)
+                                            2))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (list 1 2 3 4 5 6) :by (progn
+                                          (cl-assert (= times 0))
+                                          (cl-incf times)
+                                          2))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into (list 1 2 3 4 5 6) 'loopy--test-custom-seq)
+               :by (progn
+                     (cl-assert (= times 0))
+                     (cl-incf times)
+                     2))
+          (collect i))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-end-just-once
+  :doc "`:by' should only be evaluated once."
+  :result '(0 1 2)
+  :multi-body t
+  :body [((with (times 0))
+          (seq i (seq-into (vector 0 1 2 3 4 5 6) 'loopy--test-custom-seq)
+               :to (progn
+                     (cl-assert (= times 0))
+                     (cl-incf times)
+                     2))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into (vector 0 1 2 3 4 5 6) 'loopy--test-custom-seq)
+               :upto (progn
+                       (cl-assert (= times 0))
+                       (cl-incf times)
+                       2))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into (vector 2 1 0) 'loopy--test-custom-seq)
+               :downto (progn
+                         (cl-assert (= times 0))
+                         (cl-incf times)
+                         0))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into (vector 0 1 2 3 4 5 6) 'loopy--test-custom-seq)
+               :below (progn
+                        (cl-assert (= times 0))
+                        (cl-incf times)
+                        3))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into (vector 2 1 0) 'loopy--test-custom-seq)
+               :above (progn
+                        (cl-assert (= times 0))
+                        (cl-incf times)
+                        -1))
+          (collect i))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:index
+  :result '((0 . 4) (1 . 3) (2 . 2) (3 . 1) (4 . 0))
+  :multi-body t
+  :body [((seq i [4 3 2 1 0] :index cat)
+          (collect (cons cat i)))
+         ((seq i (list 4 3 2 1 0) :index cat)
+          (collect (cons cat i)))
+         ((seq i (seq-into (list 4 3 2 1 0) 'loopy--test-custom-seq)
+               :index cat)
+          (collect (cons cat i)))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:from-:downto-:by
+  :result '(8 6 4 2)
+  :body ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq)
+                   :from 8 :downto 1 :by 2)
+         (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:upto
+  :result '(0 1 2 3 4 5 6 7)
+  :body  ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :upto 7)
+          (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:to
+  :result '(0 1 2 3 4 5 6 7)
+  :body  ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :to 7)
+          (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:downto
+  :result '(10 9 8 7 6 5 4 3)
+  :body  ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :downto 3)
+          (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:above
+  :result '(10 9 8)
+  :body  ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :above 7)
+          (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:below
+  :result '(0 1 2)
+  :body  ((seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq) :below 3)
+          (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:downfrom
+  :result '(5 4 3 2 1 0)
+  :body ((seq i (seq-into [0 1 2 3 4 5] 'loopy--test-custom-seq) :downfrom 5)
+         (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:upfrom
+  :result '(2 3 4 5)
+  :body ((seq i (seq-into [0 1 2 3 4 5] 'loopy--test-custom-seq) :upfrom 2)
+         (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-multi-seq
+  :result '((1 3) (1 4) (2 3) (2 4))
+  :body ((seq i [1 2] (seq-into '(3 4) 'loopy--test-custom-seq))
+         (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-multi-seq-:by
+  :result '((1 3)  (2 3))
+  :body ((seq i [1 2] (seq-into '(3 4) 'loopy--test-custom-seq) :by 2)
+         (collect i))
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:test
+  :result '(8 6 4 2)
+  :multi-body t
+  :body [((with (start 8)
+                (end 2)
+                (step -2))
+          (seq i [0 1 2 3 4 5 6 7 8 9 10]
+               :from start :to end :by step
+               :test #'>=)
+          (collect i))
+         ((with (start 8)
+                (end 2)
+                (step -2))
+          (seq i (seq-into [0 1 2 3 4 5 6 7 8 9 10] 'loopy--test-custom-seq)
+               :from start :to end :by step
+               :test #'>=)
+          (collect i))
+         ((with (start 8)
+                (end 2)
+                (step -2))
+          (seq i '(0 1 2 3 4 5 6 7 8 9 10)
+               :from start :to end :by step
+               :test #'>=)
+          (collect i))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
+              (collect . collecting)))
+
+(loopy-deftest seq-:test-just-once
+  :result '(2 4 6 8)
+  :multi-body t
+  :body [((with (times 0))
+          (seq i [0 1 2 3 4 5 6 7 8 9 10]
+               :from 2 :to 8 :by 2
+               :test (progn
+                       (cl-assert (= times 0))
+                       (cl-incf times)
+                       #'<=))
+          (collect i))
+
+         ((with (times 0))
+          (seq i '(0 1 2 3 4 5 6 7 8 9 10)
+               :from 2 :to 8 :by 2
+               :test (progn
+                       (cl-assert (= times 0))
+                       (cl-incf times)
+                       #'<=))
+          (collect i))
+
+         ((with (times 0))
+          (seq i (seq-into '(0 1 2 3 4 5 6 7 8 9 10) 'loopy--test-custom-seq)
+               :from 2 :to 8 :by 2
+               :test (progn
+                       (cl-assert (= times 0))
+                       (cl-incf times)
+                       #'<=))
+          (collect i))]
+  :loopy t
+  :iter-keyword (seq collect)
+  :iter-bare ((seq . seqing)
               (collect . collecting)))
 
 ;;;;; Seq Index
@@ -2731,154 +3195,168 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((seq-index . sequencing-index)
               (collect . collecting)))
 
-;;;;; Seq Ref
-(loopy-deftest seq-ref
+;;;;; Sequence Ref
+(loopy-deftest sequence-ref
   :result '(7 7 7 7)
   :body ((with (my-seq '(1 2 3 4)))
          (_cmd i my-seq)
          (do (setf i 7))
          (finally-return my-seq))
   :repeat _cmd
-  :loopy ((_cmd . (sequence-ref sequencef seq-ref seqf)))
-  :iter-keyword ((_cmd . (sequence-ref sequencef seq-ref seqf))
+  :loopy ((_cmd . (sequence-ref sequencef sequence-ref)))
+  :iter-keyword ((_cmd . (sequence-ref sequencef sequence-ref))
                  (do . do))
   :iter-bare ((_cmd . (sequencing-ref))
               (do . ignore)))
 
-(loopy-deftest seq-ref-:by-array
+(loopy-deftest sequence-ref-not-seq
+  :doc "Check that `sequence-ref' does not correctly work on `seq'.
+If it does, we confused them somewhere in the setup code.  Custom types
+are records, which are sequences, so they still work in that way."
+  :result (record 7 7 7)
+  :body ((with (my-seq (seq-into '(1 2 3 4) 'loopy--test-custom-seq)))
+         (sequence-ref i my-seq)
+         (do (setf i 7))
+         (finally-return my-seq))
+  :loopy t
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
+              (do . ignore)))
+
+(loopy-deftest sequence-ref-:by-array
   :result "a1a3a5a7a9"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :by 2)
+         (sequence-ref i my-str :by 2)
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:by-list
+(loopy-deftest sequence-ref-:by-list
   :result '(99 1 99 3 99 5 99 7 99 9 99)
   :body ((with (my-list (list 0 1 2 3 4 5 6 7 8 9 10) ))
-         (seq-ref i my-list :by 2)
+         (sequence-ref i my-list :by 2)
          (do (setf i 99))
          (finally-return my-list))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:by-just-once
+(loopy-deftest sequence-ref-:by-just-once
   :result "a1a3a5a7a9"
   :body ((with (my-str "0123456789")
                (times 0))
-         (seq-ref i my-str :by (progn
-                                 (cl-assert (= times 0))
-                                 (cl-incf times)
-                                 2))
+         (sequence-ref i my-str :by (progn
+                                      (cl-assert (= times 0))
+                                      (cl-incf times)
+                                      2))
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:by-:index
+(loopy-deftest sequence-ref-:by-:index
   :result  "a1a3a5a7a9"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :by 2 :index cat)
-         (do (setf (aref my-str cat) ?a))
+         (sequence-ref i my-str :by 2 :index cat)
+         (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:from-:by
+(loopy-deftest sequence-ref-:from-:by
   :result  '(0 cat 2 cat 4 cat 6 cat 8 cat)
   :body ((with (my-list (list 0 1 2 3 4 5 6 7 8 9)))
-         (seq-ref i my-list :from 1 :by 2 )
+         (sequence-ref i my-list :from 1 :by 2 )
          (do (setf i 'cat))
          (finally-return my-list))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:downto-:by
+(loopy-deftest sequence-ref-:downto-:by
   :result  "0123456a8a"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :downto 6 :by 2 )
+         (sequence-ref i my-str :downto 6 :by 2 )
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:below
+(loopy-deftest sequence-ref-:below
   :result  "aaaaa56789"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :below 5)
+         (sequence-ref i my-str :below 5)
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:above
+(loopy-deftest sequence-ref-:above
   :result  "012345aaaa"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :above 5)
+         (sequence-ref i my-str :above 5)
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:above-list
+(loopy-deftest sequence-ref-:above-list
   :result  '(0 1 2 3 4 5 cat cat cat cat)
   :body ((with (my-list (list 0 1 2 3 4 5 6 7 8 9)))
-         (seq-ref i my-list :above 5)
+         (sequence-ref i my-list :above 5)
          (do (setf i 'cat))
          (finally-return my-list))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:upto
+(loopy-deftest sequence-ref-:upto
   :result  "aaaaaa6789"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :upto 5)
+         (sequence-ref i my-str :upto 5)
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:upfrom-:by
+(loopy-deftest sequence-ref-:upfrom-:by
   :result  "0a2a4a6a8a"
   :body ((with (my-str "0123456789"))
-         (seq-ref i my-str :upfrom 1 :by 2 )
+         (sequence-ref i my-str :upfrom 1 :by 2 )
          (do (setf i ?a))
          (finally-return my-str))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
-(loopy-deftest seq-ref-:upfrom-:by-string
+(loopy-deftest sequence-ref-:upfrom-:by-string
   :result  '(0 cat 2 cat 4 cat 6 cat 8 cat)
   :body ((with (my-list (list 0 1 2 3 4 5 6 7 8 9)))
-         (seq-ref i my-list :upfrom 1 :by 2)
+         (sequence-ref i my-list :upfrom 1 :by 2)
          (do (setf i 'cat))
          (finally-return my-list))
   :loopy t
-  :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
 (loopy-deftest sequence-ref-:downfrom
@@ -2892,6 +3370,227 @@ Using numbers directly will use less variables and more efficient code."
   :iter-bare ((sequence-ref . sequencing-ref)
               (do . ignore)))
 
+(loopy-deftest sequence-ref-:by-literal
+  :doc "`sequence-ref' can use literal `:by' directly."
+  :result [0 1 22 3 22 5 22 7 22 9 10]
+  :body ((with (start 2) (end 8)
+               (arr (cl-coerce (number-sequence 0 10) 'vector)))
+         (sequence-ref i arr :from start :to end :by 2)
+         (do (setf i 22))
+         (finally-return arr))
+  :loopy t
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
+              (do . ignore)))
+
+(loopy-deftest sequence-ref-:by-variable
+  :doc "`sequence-ref' can use literal `:by' directly."
+  :result [0 1 22 3 22 5 22 7 22 9 10]
+  :body ((with (start 2) (end 8) (step 2)
+               (arr (cl-coerce (number-sequence 0 10) 'vector)))
+         (sequence-ref i arr :from start :to end :by step)
+         (do (setf i 22))
+         (finally-return arr))
+  :loopy t
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
+              (do . ignore)))
+
+(loopy-deftest sequence-ref-destructuring
+  :doc "Check that `sequence-ref' implements destructuring. Not destructuring itself."
+  :result [(7 8 9) (7 8 9)]
+  :body ((with (my-seq [(1 2 3) (4 5 6)]))
+         (sequence-ref (i j k) my-seq)
+         (do (setf i 7)
+             (setf j 8)
+             (setf k 9))
+         (finally-return my-seq))
+  :loopy t
+  :iter-keyword (sequence-ref do)
+  :iter-bare ((sequence-ref . sequencing-ref)
+              (do . ignore)))
+
+;;;;; Seq Ref
+(loopy-deftest seq-ref
+  :result (seq-into '(7 7 7 7) 'loopy--test-custom-seq)
+  :body ((with (my-seq (seq-into '(1 2 3 4) 'loopy--test-custom-seq)))
+         (_cmd i my-seq)
+         (do (setf i 7))
+         (finally-return my-seq))
+  :repeat _cmd
+  :loopy ((_cmd . (seq-ref seqing-ref seqf)))
+  :iter-keyword ((_cmd . (seq-ref seqing-ref seqf))
+                 (do . do))
+  :iter-bare ((_cmd . (seqing-ref))
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:by-array
+  :result "a1a3a5a7a9"
+  :body ((with (my-str "0123456789"))
+         (seq-ref i my-str :by 2)
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:by-list
+  :result '(99 1 99 3 99 5 99 7 99 9 99)
+  :body ((with (my-list (list 0 1 2 3 4 5 6 7 8 9 10) ))
+         (seq-ref i my-list :by 2)
+         (do (setf i 99))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:by-custom-seq
+  :result (seq-into '(99 1 99 3 99 5 99 7 99 9 99)
+                    'loopy--test-custom-seq)
+  :body ((with (my-list (seq-into (list 0 1 2 3 4 5 6 7 8 9 10)
+                                  'loopy--test-custom-seq)))
+         (seq-ref i my-list :by 2)
+         (do (setf i 99))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:by-just-once
+  :result (seq-into "a1a3a5a7a9" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq))
+               (times 0))
+         (seq-ref i my-str :by (progn
+                                 (cl-assert (= times 0))
+                                 (cl-incf times)
+                                 2))
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:by-:index
+  :result  (seq-into "a1a3a5a7a9" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :by 2 :index cat)
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:from-:by
+  :result  (seq-into '(0 cat 2 cat 4 cat 6 cat 8 cat)
+                     'loopy--test-custom-seq)
+  :body ((with (my-list (seq-into (list 0 1 2 3 4 5 6 7 8 9)
+                                  'loopy--test-custom-seq)))
+         (seq-ref i my-list :from 1 :by 2 )
+         (do (setf i 'cat))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:downto-:by
+  :result  (seq-into "0123456a8a" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :downto 6 :by 2 )
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:below
+  :result  (seq-into "aaaaa56789" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :below 5)
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:above
+  :result  (seq-into "012345aaaa" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :above 5)
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:above-list
+  :result  (seq-into '(0 1 2 3 4 5 cat cat cat cat) 'loopy--test-custom-seq)
+  :body ((with (my-list (seq-into (list 0 1 2 3 4 5 6 7 8 9)
+                                  'loopy--test-custom-seq)))
+         (seq-ref i my-list :above 5)
+         (do (setf i 'cat))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:upto
+  :result  (seq-into "aaaaaa6789" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :upto 5)
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:upfrom-:by
+  :result  (seq-into "0a2a4a6a8a" 'loopy--test-custom-seq)
+  :body ((with (my-str (seq-into "0123456789" 'loopy--test-custom-seq)))
+         (seq-ref i my-str :upfrom 1 :by 2 )
+         (do (setf i ?a))
+         (finally-return my-str))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:upfrom-:by-string
+  :result  (seq-into '(0 cat 2 cat 4 cat 6 cat 8 cat)
+                     'loopy--test-custom-seq)
+  :body ((with (my-list (seq-into (list 0 1 2 3 4 5 6 7 8 9)
+                                  'loopy--test-custom-seq)))
+         (seq-ref i my-list :upfrom 1 :by 2)
+         (do (setf i 'cat))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
+(loopy-deftest seq-ref-:downfrom
+  :result (seq-into '(0 cat 2 cat 4 cat 6 7 8 9)
+                    'loopy--test-custom-seq)
+  :body ((with (my-list (seq-into (list 0 1 2 3 4 5 6 7 8 9)
+                                  'loopy--test-custom-seq)))
+         (seq-ref i my-list :downfrom 5 :by 2)
+         (do (setf i 'cat))
+         (finally-return my-list))
+  :loopy t
+  :iter-keyword (seq-ref do)
+  :iter-bare ((seq-ref . seqing-ref)
+              (do . ignore)))
+
 (loopy-deftest seq-ref-:by-literal
   :doc "`seq-ref' can use literal `:by' directly."
   :result [0 1 22 3 22 5 22 7 22 9 10]
@@ -2902,26 +3601,26 @@ Using numbers directly will use less variables and more efficient code."
          (finally-return arr))
   :loopy t
   :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-bare ((seq-ref . seqing-ref)
               (do . ignore)))
 
 (loopy-deftest seq-ref-:by-variable
   :doc "`seq-ref' can use literal `:by' directly."
-  :result [0 1 22 3 22 5 22 7 22 9 10]
+  :result (seq-into [0 1 22 3 22 5 22 7 22 9 10] 'loopy--test-custom-seq)
   :body ((with (start 2) (end 8) (step 2)
-               (arr (cl-coerce (number-sequence 0 10) 'vector)))
+               (arr (seq-into (number-sequence 0 10) 'loopy--test-custom-seq)))
          (seq-ref i arr :from start :to end :by step)
          (do (setf i 22))
          (finally-return arr))
   :loopy t
   :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-bare ((seq-ref . seqing-ref)
               (do . ignore)))
 
 (loopy-deftest seq-ref-destructuring
   :doc "Check that `seq-ref' implements destructuring. Not destructuring itself."
-  :result [(7 8 9) (7 8 9)]
-  :body ((with (my-seq [(1 2 3) (4 5 6)]))
+  :result (seq-into [(7 8 9) (7 8 9)] 'loopy--test-custom-seq)
+  :body ((with (my-seq (seq-into [(1 2 3) (4 5 6)] 'loopy--test-custom-seq)))
          (seq-ref (i j k) my-seq)
          (do (setf i 7)
              (setf j 8)
@@ -2929,7 +3628,7 @@ Using numbers directly will use less variables and more efficient code."
          (finally-return my-seq))
   :loopy t
   :iter-keyword (seq-ref do)
-  :iter-bare ((seq-ref . sequencing-ref)
+  :iter-bare ((seq-ref . seqing-ref)
               (do . ignore)))
 
 ;;;;; Stream


### PR DESCRIPTION
- Create command `seq`.
  - Remove `seq` as an alias for `sequence`.
  - Duplicate `sequence` tests for `seq`.
  - Add test `sequence-not-seq` to make sure we didn't confuse the two anywhere.

- Create command `seq-ref`.
  - Remove `seq-ref` as an alias for `sequence-ref`.
  - Duplicate `sequence-ref` tests for `seq-ref`.
  - Add test `sequence-ref-not-seq-ref` to make sure we didn't confuse the two
    anywhere.

- Make `sequence-index` compatible with `seq`s.

- Create custom sequence type for testing generic sequence commands.

- Change `loopy--obsolete-aliases` so that `seqf` and `seqingf` are obsolete
  aliases of `seq-ref`, not of `sequence-ref`.

- Update Org documentation, CHANGELOG, and README.
  - Note that not all generic sequences are mutable.
  - List `seqing-index` and `seqing-ref` as accepted names for Loopy Iter.

- Rename parsers `loopy--parse-seq-index` to `loopy--parse-sequence-index`,
  `loopy--parse-seq` to `loopy--parse-sequence`,
  and `loopy--parse-seq-ref` to `loopy--parse-sequence-ref`.

- Fix `sequence-ref-:by-index` (formerly `seq-ref-:by-index`) so that it
  correctly tests the generalized variable setter.