### PR TITLE
Remove outdated loopy-pkg.el

### DIFF
--- a/loopy-pkg.el
+++ b/loopy-pkg.el
@@ -1,9 +1,0 @@
-(define-package "loopy" "0.13.0"
-  "A looping macro"
-  '((emacs "27.1")
-    (map   "3.3.1")
-    (seq   "2.22")
-    (compat "29.1.3")
-    (stream "2.3.0"))
-  :homepage "https://github.com/okamsn/loopy"
-  :keywords '("extensions"))


### PR DESCRIPTION
The information in `loopy-pkg.el` did not agree with the information in `loopy.el`.  This pull-requests addresses that be removing the outdated `loopy-pkg.el`.

While the end-user package manager `package.el` expects a file `<name>-pkg.el`, this should only be generate by the package archive (such as GNU ELPA and MELPA), instead of being tracked in the upstream repository.

The tools used maintain the various *ELPA, do *not* use `<name>-pkg.el` as a data *source*, they only generate it it.

- `elpa-admin.el`, the tool used for GNU ELPA and NonGNU ELPA, does *not* use `<name>-pkg.el` as a data source and it never has.

- `package-build.el`, the tool used for Melpa, prefers `<name>.el` but *currently* falls back to get information missing from there from `<name>-pkg.el` instead. I am goint to change that; soon `<name>-pkg.el` will be ignored as a data source by this tool too.