### PR TITLE
Deprecate the behavior of `set` with no values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This document describes the user-facing changes to Loopy.
 
 For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 
+## Unreleased
+
+### Breaking Changes
+
+- `set` now warns when it is not given a value ([#229]).  Currently, `(set VAR)`
+  binds `VAR` to `nil`, but since this form is indistinguishable from a mistake,
+  and since `nil` is a short word to write, this behavior is deprecated.
+
+[#229]: https://github.com/okamsn/loopy/PR/229
+
 ## 0.14.0
 
 ### Commands for Generic (`seq.el`) Sequences

--- a/README.org
+++ b/README.org
@@ -35,6 +35,9 @@ please let me know.
 -----
 
  _Recent breaking changes:_
+ - Unreleased:
+   - =set= now warns when it is not given a value.  In the future, it will
+     signal an error.
  - Version 0.14.0:
    - Conflicting initialization values for accumulation variables now signal
      a warning.  In the future, they will signal an error.

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -1324,11 +1324,8 @@ value and do no affect how the loop iterates.
 
 #+findex: set
 #+findex: setting
-#+findex: expr
-#+findex: exprs
-- =(set VAR [EXPRS])= :: Bind =VAR= to each =EXPR= in order.  Once the last
-  =EXPR= is reached, it is used repeatedly for the rest of the loop.  With no
-  =EXPR=, =VAR= is bound to ~nil~ during each iteration of the loop.
+- =(set VAR EXPR [EXPRS])= :: Bind =VAR= to each =EXPR= in order.  Once the last
+  =EXPR= is reached, it is used repeatedly for the rest of the loop.
 
   This command also has the aliases =setting=.
 

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -705,7 +705,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting something like the below example might not do what you expect, as @samp{i}
 is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,org98ed280
+@float Listing,org3151e6b
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -887,7 +887,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,org68c72e4
+@float Listing,org7bf92c8
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -902,7 +902,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,orgebc9f13
+@float Listing,org0853253
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -1473,13 +1473,10 @@ expressions.  Currently, this command is only useful when used within the
 
 @findex set
 @findex setting
-@findex expr
-@findex exprs
 @table @asis
-@item @samp{(set VAR [EXPRS])}
+@item @samp{(set VAR EXPR [EXPRS])}
 Bind @samp{VAR} to each @samp{EXPR} in order.  Once the last
-@samp{EXPR} is reached, it is used repeatedly for the rest of the loop.  With no
-@samp{EXPR}, @samp{VAR} is bound to @code{nil} during each iteration of the loop.
+@samp{EXPR} is reached, it is used repeatedly for the rest of the loop.
 
 This command also has the aliases @samp{setting}.
 
@@ -1637,7 +1634,7 @@ cases, which has a minor speed cost.
          collect num into nums-2
          finally return (list num nums-1 nums-2))
 
-;; => (4 (nil 2 3 4) (1 2 3 4))
+;; => (4 (nil 1 2 3) (1 2 3 4))
 (loopy (list elem (list 1 2 3 4))
        (collect nums-1 num)
        (numbers num :from 1)
@@ -1647,12 +1644,12 @@ cases, which has a minor speed cost.
 
 Generally, iteration commands with conditions check whether to terminate the
 loop @emph{before} the next iteration is run.  They do not check their conditions
-while running the current iteration.  In the below example, note that the final
-value of @code{i} is 2 and not 3, even though the @samp{do} command (similar to
+while running the current iteration step.  In the below example, note that the
+final value of @code{i} is 2 and not 3, even though the @samp{do} command (similar to
 @code{cl-loop}'s @samp{do} keyword) is placed before the @samp{list} command.  Even though @code{i}
-is updated before @code{elem} is updated, the @samp{list} command's condition that decides
-whether to continue the loop is checked @emph{before} the code in the @samp{do} command is
-run.
+is updated before @code{elem} is updated, the decision whether to continue the loop,
+based on the @samp{list} command's condition, is made @emph{before} the code in the @samp{do}
+command is run.
 
 @lisp
 ;; => 2, not 3
@@ -4853,7 +4850,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-aliases}.
 
-@float Listing,orge9aa92e
+@float Listing,org0bc3841
 @lisp
 ;; => ((1 2 3) (-3 -2 -1) (0))
 (loopy-iter (arg accum-opt positives negatives other)

--- a/lisp/loopy-commands.el
+++ b/lisp/loopy-commands.el
@@ -143,7 +143,7 @@ handled by `loopy-iter'."
 
 ;;;;; Genereric Evaluation
 ;;;;;; Set
-(cl-defun loopy--parse-set-command ((_ var &rest vals))
+(cl-defun loopy--parse-set-command ((&whole cmd name var &rest vals))
   "Parse the `set' command.
 
 - VAR is the variable to assign.
@@ -152,7 +152,10 @@ handled by `loopy-iter'."
          (arg-length (length vals)))
     (cl-case arg-length
       ;; If no values, repeatedly set to `nil'.
-      (0 (loopy--destructure-for-other-command
+      (0 (warn "`loopy': `%s' will require at least 1 value in the future: `%s'"
+               name
+               cmd)
+         (loopy--destructure-for-other-command
           var nil))
       ;; If one value, repeatedly set to that value.
       (1 (loopy--destructure-for-other-command


### PR DESCRIPTION
Currently, `(set VAR)` will set `VAR` to `nil`.  Because this is likely a
mistake and because `nil` is a short word to type for greater clarity, deprecate
this behavior and signal a warning.