### PR TITLE
Separate `when` and `unless` into separate commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 
 ## Unreleased
 
+### Bug Fixes
+
+- `when` and `unless` now correctly work when aliased ([#234], [#240]).
+
 ### Breaking Changes
 
 - `set` now warns when it is not given a value ([#229]).  Currently, `(set VAR)`
@@ -21,6 +25,10 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
   There is no longer a separate mapping of aliases to original names.  However,
   `loopy-defalias` will continue to work.
 
+- Separate `when` and `unless` commands to have different parsing functions
+  ([#234], [#240]).  The old implementation used the name of the command in the
+  generated code and was written before aliases.
+
 ### Internal Changes
 
 - As far as the implementation is concerned, "aliases" are no longer a separate
@@ -33,7 +41,9 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 
 
 [#229]: https://github.com/okamsn/loopy/PR/229
+[#234]: https://github.com/okamsn/loopy/issues/234
 [#237]: https://github.com/okamsn/loopy/PR/237
+[#240]: https://github.com/okamsn/loopy/PR/240
 
 
 ## 0.14.0

--- a/README.org
+++ b/README.org
@@ -41,6 +41,8 @@ please let me know.
    - ~loopy-command-parsers~ and ~loopy-aliases~ are deprecated in favor of
      a single hash table in the new user option ~loopy-parsers~.  This
      simplified the code and will make adding local overrides easier.
+   - =when= and =unless= are now implemented separately, fixing when the
+     commands are aliased.
  - Version 0.14.0:
    - Conflicting initialization values for accumulation variables now signal
      a warning.  In the future, they will signal an error.

--- a/lisp/loopy-commands.el
+++ b/lisp/loopy-commands.el
@@ -336,24 +336,23 @@ command are inserted into a `cond' special form."
     (cons `(loopy--main-body (cond ,@(nreverse cond-body)))
           (apply #'append (nreverse rest-instructions)))))
 
-;;;;;; When Unless
-(cl-defun loopy--parse-when-unless-command ((name condition &rest body))
-  "Parse `when' and `unless' commands as (when/unless CONDITION [COMMANDS]).
+;;;;;; When
+(cl-defun loopy--parse-when-command ((_ condition &rest body))
+  "Parse `when' as (when CONDITION [COMMANDS]."
+  (let ((loopy--in-sub-level t))
+    (loopy--bind-main-body (main other)
+        (loopy--parse-loop-commands body)
+      `((loopy--main-body (when ,condition ,@main))
+        ,@other))))
 
-- NAME is `when' or `unless'.
-- CONDITION is the condition.
-- BODY is the sub-commands."
-  (let ((loopy--in-sub-level t)
-        (when-body)
-        (other-instructions))
-    (dolist (cmd body)
-      (cl-destructuring-bind (main-body rest)
-          (loopy--extract-main-body (loopy--parse-loop-command cmd))
-        (push main-body when-body)
-        (push rest other-instructions)))
-    (cons `(loopy--main-body
-            (,name ,condition ,@(apply #'append (nreverse when-body))))
-          (apply #'append (nreverse other-instructions)))))
+;;;;;; Unless
+(cl-defun loopy--parse-unless-command ((_ condition &rest body))
+  "Parse `when' as (when CONDITION [COMMANDS]."
+  (let ((loopy--in-sub-level t))
+    (loopy--bind-main-body (main other)
+        (loopy--parse-loop-commands body)
+      `((loopy--main-body (unless ,condition ,@main))
+        ,@other))))
 
 ;;;;; Iteration
 (cl-defmacro loopy--defiteration

--- a/lisp/loopy-vars.el
+++ b/lisp/loopy-vars.el
@@ -320,8 +320,8 @@ Definition must exist.  Neither argument need be quoted."
            unioning          loopy--parse-union-command
            vconcat           loopy--parse-vconcat-command
            vconcating        loopy--parse-vconcat-command
-           unless            loopy--parse-when-unless-command
-           when              loopy--parse-when-unless-command
+           unless            loopy--parse-unless-command
+           when              loopy--parse-when-command
            until             loopy--parse-while-until-commands
            while             loopy--parse-while-until-commands
            loopy-iter        loopy-iter--parse-loopy-iter-command))

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -5976,6 +5976,15 @@ Multiple of 3: 6"
          (finally-return (string-join (nreverse msg-coll) "\n")))
   :loopy t)
 
+(loopy-deftest when-alias
+  :doc "Make sure aliases don't show up in `when' instead of the symbol `when'."
+  :result 1
+  :wrap ((x . `(let ((loopy-parsers
+                      (my-ht-map-insert loopy-parsers 'w (map-elt loopy-parsers 'when))))
+                 (eval (quote ,x) t))))
+  :body ((w t (return 1)))
+  :loopy t)
+
 ;;;;; Unless
 (loopy-deftest multi-unless-prepend-test
   :result "Not multiple of 2: 1
@@ -5996,6 +6005,15 @@ Not multiple of 3: 7"
          (unless (zerop (mod el second-var))
            (push-into msg-coll (format "Not multiple of 3: %d" el)))
          (finally-return (string-join (nreverse msg-coll) "\n")))
+  :loopy t)
+
+(loopy-deftest unless-alias
+  :doc "Make sure aliases don't show up in `unless' instead of the symbol `unless'."
+  :result 1
+  :wrap ((x . `(let ((loopy-parsers
+                      (my-ht-map-insert loopy-parsers 'u (map-elt loopy-parsers 'unless))))
+                 (eval (quote ,x) t))))
+  :body ((u nil (return 1)))
   :loopy t)
 
 ;;;;; Cond FORMS


### PR DESCRIPTION
The old implementation used the name of the command in the generated code and
was written before aliases.  It would try to use the alias name in the output
instead of the symbols `when` or `unless`.

Fixes #234.

- Add parser `loopy--parse-when-command`
- Add test `when-alias`
- Add parser `loopy--parse-unless-command`
- Add test `unless-alias`
- Remove `loopy--parse-when-unless-command`