### PR TITLE
Combine `loopy-iter-bare-commands` and `loopy-iter-bare-special-macro-arguments`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,20 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
   binds `VAR` to `nil`, but since this form is indistinguishable from a mistake,
   and since `nil` is a short word to write, this behavior is deprecated.
 
-- `loopy-command-parsers` and `loopy-aliases` are both deprecated in favor of
-  the newly added `loopy-parsers` ([#237]).  The new user option simplifies the
-  code internally, making it easier to add local overrides in the future, which
-  will make code which custom commands more portable.
+- Some variables were combined to simplify the code internally and make it
+  easier to add local overrides in the future, which will make code which custom
+  commands more portable.
 
-  The new user option is a hash table which maps symbols to parsing functions.
-  There is no longer a separate mapping of aliases to original names.  However,
-  `loopy-defalias` will continue to work.
+  - `loopy-command-parsers` and `loopy-aliases` are both deprecated in favor of
+    the newly added `loopy-parsers` ([#237]).  The new user option is a hash
+    table which maps symbols to parsing functions.  There is no longer a
+    separate mapping of aliases to original names.  However, `loopy-defalias`
+    will continue to work.
+
+  - `loopy-iter-bare-special-marco-arguments` and `loopy-iter-bare-commands` are
+    both deprecated in favor of the newly added `loopy-iter-bare-names` ([#242],
+    [#238]). The new user option is a list which by default contains all symbols
+    previously listed in the old variables.
 
 - Separate `when` and `unless` commands to have different parsing functions
   ([#234], [#240]).  The old implementation used the name of the command in the
@@ -44,8 +50,10 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 [#229]: https://github.com/okamsn/loopy/PR/229
 [#234]: https://github.com/okamsn/loopy/issues/234
 [#237]: https://github.com/okamsn/loopy/PR/237
+[#238]: https://github.com/okamsn/loopy/issues/238
 [#240]: https://github.com/okamsn/loopy/PR/240
 [#241]: https://github.com/okamsn/loopy/PR/241
+[#242]: https://github.com/okamsn/loopy/PR/242
 
 ## 0.14.0
 

--- a/README.org
+++ b/README.org
@@ -41,6 +41,8 @@ please let me know.
    - ~loopy-command-parsers~ and ~loopy-aliases~ are deprecated in favor of
      a single hash table in the new user option ~loopy-parsers~.  This
      simplified the code and will make adding local overrides easier.
+   - ~loopy-iter-bare-special-macro-arguments~ and ~loopy-iter-bare-commands~
+     are deprecated in favor of the single variable ~loopy-iter-bare-names~.
    - =when= and =unless= are now implemented separately, fixing when the
      commands are aliased.
  - Version 0.14.0:

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -4511,8 +4511,8 @@ which loop commands are treated as macros to be expanded by ~macroexpand-all~.
 Hence, a loop command could overshadow the function value of a symbol.  There
 are two ways to avoid such conflicts.
 
-#+cindex: loopy-iter bare commands
-#+vindex: loopy-iter-bare-commands
+#+cindex: loopy-iter bare names
+#+vindex: loopy-iter-bare-names
 The first way is to use non-conflicting aliases.  Like in Iterate (and
 ~cl-loop~, to an extent), almost all commands in ~loopy~ have aliases in the
 present-participle form (the "-ing" form).  For example, Loopy provides the
@@ -4540,17 +4540,17 @@ arguments that are recognized by default are given in [[#iter-default-names]].
                           (at outer (collecting j))))
 #+end_src
 
-The non-conflicting command aliases recognized by ~loopy-iter~ can be customized
-with the user option ~loopy-iter-bare-commands~, which is a list of symbols
-naming commands and their aliases.  Again, these commands are found in the loop
-body by using Emacs Lisp's macro-expansion features, so adding an alias that
-overrides a symbol's function definition can cause errors.  ~loopy~, whose
-environment is more limited, does not have this restriction.
-
-#+vindex: loopy-iter-bare-special-macro-arguments
-The special macro arguments (and their aliases) recognized by ~loopy-iter~ can
-be set in the user option ~loopy-iter-bare-special-macro-arguments~.  Some of
-their built-in aliases, such as =let*= for =with=, are excluded by default.
+The non-conflicting names of loop commands and special macro arguments
+recognized by ~loopy-iter~ can be customized with the user option
+~loopy-iter-bare-names~, which is a list of symbols naming commands, special
+macro arguments, and their aliases.  Again, these symbols are found in the loop
+body by using Emacs Lisp's macro-expansion features, so adding a name that
+overrides a symbol's function definition can cause errors. Names that are
+obvious conflicts, such as the non-suffixed versions of most loop commands (such
+as =list=), loop commands that are unneeded in ~loopy-iter~ (such as =when=),
+and the names of Loopy features that are the same as the names of Emacs Lisp
+features (such as =let*= for =with=) are by default excluded from
+~loopy-iter-bare-names~.
 
 #+cindex: loopy-iter keywords
 #+vindex: loopy-iter-keywords
@@ -4673,8 +4673,7 @@ Finally, there are a few things to keep in mind when using ~loopy-iter~:
 
 This section lists the default aliases supported as bare names in the macro
 ~loopy-iter~.  The list of supported bare names can be customized in the user
-options ~loopy-iter-bare-commands~ and
-~loopy-iter-bare-special-macro-arguments~.
+options ~loopy-iter-bare-names~.
 
 By default, the following commands are not recognized:
 - =do= and =command-do=, which are not needed.

--- a/lisp/loopy-vars.el
+++ b/lisp/loopy-vars.el
@@ -157,6 +157,10 @@ Definition must exist.  Neither argument need be quoted."
   #s(hash-table
      test eq
      data (;; Special macro arguments
+           ;;
+           ;; NOTE: When editing the hash table, also edit the list of
+           ;; pseudo-functions for special macro arguments used in the
+           ;; definition of `loopy-iter'.
            accum-opt          loopy--parse-accum-opt-special-macro-argument
            opt-accum          loopy--parse-accum-opt-special-macro-argument
            after              loopy--parse-after-do-special-macro-argument

--- a/tests/iter-tests.el
+++ b/tests/iter-tests.el
@@ -31,6 +31,11 @@
                       (repeating 3)
                       (collecting (list a b c)))))
 
+(ert-deftest bare-names ()
+  (let ((loopy-iter-bare-names (cons 'array loopy-iter-bare-names)))
+    (should (equal '(0 1 2 3)
+                   (liq (array i [0 1 2 3])
+                        (collecting i))))))
 
 ;; A list of special-form code walkers in Iterate. In Emacs Lisp, many of these
 ;; are macros, and so we should not need to test them, as they expand to simpler

--- a/tests/tests.el
+++ b/tests/tests.el
@@ -3860,8 +3860,8 @@ expansion time."
                                                   #'my-loopy-sum-command1)
                                       (map-insert 'sum2
                                                   #'my-loopy-sum-command2)))
-                       (loopy-iter-bare-commands (append '(sum1 sum2)
-                                                         loopy-iter-bare-commands)))
+                       (loopy-iter-bare-names (append '(sum1 sum2)
+                                                      loopy-iter-bare-names)))
                    (eval (quote ,x) t)))))
   :multi-body t
   :body [((list i '(1 2 3 4 5))
@@ -3929,8 +3929,8 @@ expansion time."
                  (let ((loopy-parsers (thread-first loopy-parsers
                                                     (my-ht-map-insert 'sum1 #'my-loopy-sum-command1)
                                                     (my-ht-map-insert 'sum2 #'my-loopy-sum-command2)))
-                       (loopy-iter-bare-commands (append '(sum1 sum2)
-                                                         loopy-iter-bare-commands)))
+                       (loopy-iter-bare-names (append '(sum1 sum2)
+                                                      loopy-iter-bare-names)))
                    (eval (quote ,x) t)))))
   :multi-body t
   :body [((list i '(1 2 3 4 5))
@@ -6652,8 +6652,8 @@ Wrapping with another eval to make sure variables are set by expansion time."
                  (let ((loopy-command-parsers
                         (map-insert loopy-command-parsers 'target-sum
                                     #'my-loopy-sum-command))
-                       (loopy-iter-bare-commands (cons 'target-sum
-                                                       loopy-iter-bare-commands)))
+                       (loopy-iter-bare-names (cons 'target-sum
+                                                    loopy-iter-bare-names)))
                    (eval (quote ,x) t)))))
   :result 6
   :body ((target-sum my-target 1 2 3)
@@ -6672,8 +6672,8 @@ Wrapping with another eval to make sure variables are set by expansion time."
                  (let ((loopy-parsers (my-ht-map-insert loopy-parsers
                                                         'target-sum
                                                         #'my-loopy-sum-command))
-                       (loopy-iter-bare-commands (cons 'target-sum
-                                                       loopy-iter-bare-commands)))
+                       (loopy-iter-bare-names (cons 'target-sum
+                                                    loopy-iter-bare-names)))
                    (eval (quote ,x) t)))))
   :result 6
   :body ((target-sum my-target 1 2 3)
@@ -6709,8 +6709,8 @@ Otherwise, `loopy' should return t."
                  (let ((loopy-command-parsers
                         (map-insert loopy-command-parsers 'my-always
                                     #'my--loopy-always-command-parser))
-                       (loopy-iter-bare-commands (cons 'my-always
-                                                       loopy-iter-bare-commands)))
+                       (loopy-iter-bare-names (cons 'my-always
+                                                    loopy-iter-bare-names)))
                    (eval (quote ,x) t)))))
   :result t
   :body ((list i (number-sequence 1 9))
@@ -6896,8 +6896,8 @@ NOTE: This should eventually be removed."
   :result '(1)
   :wrap ((x . `(let ((loopy-parsers
                       (my-ht-map-insert loopy-parsers 'f (map-elt loopy-parsers 'flag)))
-                     (loopy-iter-bare-special-macro-arguments
-                      (cons 'f loopy-iter-bare-special-macro-arguments)))
+                     (loopy-iter-bare-names
+                      (cons 'f loopy-iter-bare-names)))
                  (eval (quote ,x) t))))
   :body ((f default)
          (list i '(1))
@@ -6911,8 +6911,8 @@ NOTE: This should eventually be removed."
 (loopy-deftest custom-alias-with
   :result 1
   :wrap ((x . `(let ((loopy-parsers (my-ht-map-insert loopy-parsers 'as (map-elt loopy-parsers 'with)))
-                     (loopy-iter-bare-special-macro-arguments
-                      (cons 'as loopy-iter-bare-special-macro-arguments)))
+                     (loopy-iter-bare-names
+                      (cons 'as loopy-iter-bare-names)))
                  (eval (quote ,x) t))))
   :body ((as (a 1))
          (return a))
@@ -6925,8 +6925,8 @@ NOTE: This should eventually be removed."
   :result 5
   :wrap ((x . `(let ((loopy-parsers
                       (my-ht-map-insert loopy-parsers 'ignore (map-elt loopy-parsers 'without)))
-                     (loopy-iter-bare-special-macro-arguments
-                      (cons 'ignore loopy-iter-bare-special-macro-arguments)))
+                     (loopy-iter-bare-names
+                      (cons 'ignore loopy-iter-bare-names)))
                  (eval  (quote (let ((a 1)
                                      (b 2))
                                  ,x
@@ -6945,8 +6945,8 @@ NOTE: This should eventually be removed."
 (loopy-deftest custom-alias-before-do
   :result 7
   :wrap ((x . `(let ((loopy-aliases (map-copy loopy-aliases))
-                     (loopy-iter-bare-special-macro-arguments
-                      (cons 'precode loopy-iter-bare-special-macro-arguments)))
+                     (loopy-iter-bare-names
+                      (cons 'precode loopy-iter-bare-names)))
                  (loopy-defalias precode before-do)
                  (eval (quote ,x) t))))
   :body ((with (i 2))
@@ -6960,8 +6960,8 @@ NOTE: This should eventually be removed."
 (loopy-deftest custom-alias-after-do
   :result t
   :wrap ((x . `(let ((loopy-aliases (map-copy loopy-aliases))
-                     (loopy-iter-bare-special-macro-arguments
-                      (cons 'postcode loopy-iter-bare-special-macro-arguments)))
+                     (loopy-iter-bare-names
+                      (cons 'postcode loopy-iter-bare-names)))
                  (loopy-defalias postcode after-do)
                  (eval (quote ,x) t))))
   :body ((with (my-ret nil))


### PR DESCRIPTION
Create `loopy-iter-bare-names`, a list of symbols containing the contents of the
old values of `loopy-iter-bare-commands` and
`loopy-iter-bare-special-macro-arguments`.