### PR TITLE
Allow `finally-do` to modify an implied `loopy-result`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,38 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
   ([#234], [#240]).  The old implementation used the name of the command in the
   generated code and was written before aliases.
 
+- `finally-do` can now modify the implied return value of a loopy by modifying
+  the implied accumulation variable, which is by default `loopy-result`
+  ([#244]).  Previously, one would have needed to use `finally-return` after
+  modifying an implied `loopy-result`.
+
+  This improves consistency by allowing treating an implied `loopy-result`
+  more like other, explicit accumulation variables inside `finally-do`.
+  The cost is switching from the use of `prog1` to an `if` expression with two
+  helper variables.  This change only applies when an implied return value is
+  used with `finally-do`.  It does not affect the macro expansion when
+  `finally-return` is used.
+
+  This is technically a breaking change for those who were modifying an implied
+  `loopy-result` but did not wish those changes to be captured in the macro's
+  implied return value nor used in `finally-return` (perhaps changing the value
+  for side effects only).
+
+  ```emacs-lisp
+  ;; Previously required way:
+  ;; => (0 1 2 3)
+  (loopy (list i '(1 2 3))
+         (collect i)
+         (finally-do (push 0 loopy-result))
+         (finally-return loopy-result))
+
+  ;; Now, `finally-return' is not required:
+  ;; => (0 1 2 3)
+  (loopy (list i '(1 2 3))
+         (collect i)
+         (finally-do (push 0 loopy-result)))
+  ```
+
 ### Internal Changes
 
 - As far as the implementation is concerned, "aliases" are no longer a separate
@@ -64,6 +96,7 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 [#241]: https://github.com/okamsn/loopy/PR/241
 [#242]: https://github.com/okamsn/loopy/PR/242
 [#243]: https://github.com/okamsn/loopy/PR/243
+[#244]: https://github.com/okamsn/loopy/PR/244
 
 ## 0.14.0
 

--- a/README.org
+++ b/README.org
@@ -45,6 +45,8 @@ please let me know.
      are deprecated in favor of the single variable ~loopy-iter-bare-names~.
    - =when= and =unless= are now implemented separately, fixing when the
      commands are aliased.
+   - Modifications to an implied ~loopy-result~ in =finally-do= will now be
+     included in the implied return value of the macro.
  - Version 0.14.0:
    - Conflicting initialization values for accumulation variables now signal
      a warning.  In the future, they will signal an error.

--- a/doc/loopy-doc.org
+++ b/doc/loopy-doc.org
@@ -451,6 +451,31 @@ argument =with= is used to initialized variables.
            (finally-do 999))
   #+end_src
 
+  When used with =finally-return=, code in =finally-do= is run before code in
+  =finally-return=.
+
+  #+begin_src emacs-lisp
+    ;; => (-1 0 1 2 3)
+    (loopy (list i '(1 2 3))
+           (collect collection i)
+           (finally-do (push 0 collection))
+           (finally-return (cons -1 collection)))
+  #+end_src
+
+  =finally-do= has access to the variables created by the loop after the loop
+  finishes, including accumulation variables that you might wish to use as a
+  return value ([[#accumulation-commands]]).  For consistency with explicit
+  accumulation variables ([[#optimized-accums]]), so long as the loop completes
+  successfully, =finally-do= can modify ~loopy-result~ even when it is used
+  as an implied accumulation variable.
+
+  #+begin_src emacs-lisp
+    ;; => (0 1 2 3)
+    (loopy (list i '(1 2 3))
+           (collect i)
+           (finally-do (push 0 loopy-result)))
+  #+end_src
+
 #+pindex: finally-return
 - =finally-return= :: Return a value, regardless of how the loop completes.
   These arguments override any explicit return values given in commands like
@@ -468,6 +493,18 @@ argument =with= is used to initialized variables.
     (loopy (leave) ; Leave to avoid infinite loop.
            (finally-return 1 2))
   #+end_src
+
+  When used with =finally-do=, code in =finally-return= is run after code in
+  =finally-do=.
+
+  #+begin_src emacs-lisp
+    ;; => (-1 0 1 2 3)
+    (loopy (list i '(1 2 3))
+           (collect collection i)
+           (finally-do (push 0 collection))
+           (finally-return (cons -1 collection)))
+  #+end_src
+
 
 #+pindex: finally-protect
 #+pindex: finally-protected
@@ -2816,12 +2853,18 @@ Unlike ~cl-loop~, Loopy uses a default accumulation variable, which is named
          (when (> i 5) (leave))
          (collect i)
          (finally-return (cons 0 loopy-result)))
-#+end_src
+
+  ;; => (0 1 2 3)
+  (loopy (list i '(1 2 3))
+         (collect i)
+         (finally-do (push 0 loopy-result)))
+  #+end_src
 
 In general, you should not attempt to modify or use the value of ~loopy-result~
-during the loop, as it is not guaranteed to have a correct value when
-efficiently building sequences.  For example, it is often faster to build a list
-in reverse instead of appending to its end.  For some commands, such as those in
+during the loop when it is used as the implied accumulation variable for a
+command, as it is not guaranteed to have a correct value when efficiently
+building sequences.  For example, it is often faster to build a list in reverse
+instead of appending to its end.  For some commands, such as those in
 [[#accum-numeric]] and [[#accum-generic]], this does not matter.
 
 Be aware that explicitly named accumulation variables do not affect the implied
@@ -4109,8 +4152,11 @@ finalized.
          (finally-return loopy-result))
 #+end_src
 
-As noted in [[#macro-arguments]], the special macro argument =finally-do= does not
-affect the return value of the loop.
+As noted in [[#macro-arguments]], the return value of Lisp code given in the special
+macro argument =finally-do= does not affect the return value of the loop.
+However, =finally-do= can modify the values of variables after the loop
+completes, including ~loopy-result~ (even when used as an implied accumulation
+variable).
 
 #+begin_src emacs-lisp
   ;; => (0 1 2 3 4)
@@ -4120,6 +4166,9 @@ affect the return value of the loop.
            (leave))
          (finally-do 7))
 
+  ;; _Does not_ modify the then-current value of `loopy-result'
+  ;; returned by the `return' command:
+  ;;
   ;; => (4 3 2 1 0)
   (loopy (numbers i :to 10)
          (if (< i 5)
@@ -4127,7 +4176,25 @@ affect the return value of the loop.
            ;; Not finalized:
            (return loopy-result))
          (finally-do
+          ;; Affects what is stored in `loopy-result',
+          ;; but because of the `return' command,
+          ;; not what the macro actually returns.
           (cl-callf2 cons 22 loopy-result)))
+
+  ;; _Does_ modify the value of `loopy-result' returned by the macro:
+  ;;
+  ;; => (0 1 2 3)
+  (loopy (list i '(1 2 3))
+         (collect loopy-result i)
+         (finally-do (push 0 loopy-result))
+         (finally-return loopy-result))
+
+  ;; _Does_ modify the value of `loopy-result' returned by the macro:
+  ;;
+  ;; => (0 1 2 3)
+  (loopy (list i '(1 2 3))
+         (collect i)
+         (finally-do (push 0 loopy-result)))
 #+end_src
 
 As noted in [[#macro-arguments]], the special macro argument =finally-return=

--- a/doc/loopy.texi
+++ b/doc/loopy.texi
@@ -488,6 +488,31 @@ return value of the macro.
        ;; Doesn't affect return value:
        (finally-do 999))
 @end lisp
+
+When used with @samp{finally-return}, code in @samp{finally-do} is run before code in
+@samp{finally-return}.
+
+@lisp
+;; => (-1 0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect collection i)
+       (finally-do (push 0 collection))
+       (finally-return (cons -1 collection)))
+@end lisp
+
+@samp{finally-do} has access to the variables created by the loop after the loop
+finishes, including accumulation variables that you might wish to use as a
+return value (@ref{Accumulation}).  For consistency with explicit
+accumulation variables (@ref{Optimizing Accumulations}), so long as the loop completes
+successfully, @samp{finally-do} can modify @code{loopy-result} even when it is used
+as an implied accumulation variable.
+
+@lisp
+;; => (0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect i)
+       (finally-do (push 0 loopy-result)))
+@end lisp
 @end table
 
 @pindex finally-return
@@ -509,7 +534,19 @@ Specifying multiple values is the same as returning a list of those values.
 (loopy (leave) ; Leave to avoid infinite loop.
        (finally-return 1 2))
 @end lisp
+
+When used with @samp{finally-do}, code in @samp{finally-return} is run after code in
+@samp{finally-do}.
+
+@lisp
+;; => (-1 0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect collection i)
+       (finally-do (push 0 collection))
+       (finally-return (cons -1 collection)))
+@end lisp
 @end table
+
 
 @pindex finally-protect
 @pindex finally-protected
@@ -709,7 +746,7 @@ You should keep in mind that commands are evaluated in order.  This means that
 attempting something like the below example might not do what you expect, as @samp{i}
 is assigned a value from the list after collecting @samp{i} into @samp{coll}.
 
-@float Listing,org4bf03c0
+@float Listing,org05823f8
 @lisp
 ;; => (nil 1 2)
 (loopy (collect coll i)
@@ -898,7 +935,7 @@ the flag @samp{dash} provided by the package @samp{loopy-dash}.
 
 Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 
-@float Listing,orgb7f13a8
+@float Listing,org02ede57
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for (i . j) in '((1 . 2) (3 . 4))
@@ -913,7 +950,7 @@ Below are two examples of destructuring in @code{cl-loop} and @code{loopy}.
 @caption{Destructuring values in a list.}
 @end float
 
-@float Listing,org761e883
+@float Listing,org9a7343f
 @lisp
 ;; => (1 2 3 4)
 (cl-loop for elem in '((1 . 2) (3 . 4))
@@ -3026,12 +3063,18 @@ Unlike @code{cl-loop}, Loopy uses a default accumulation variable, which is name
        (when (> i 5) (leave))
        (collect i)
        (finally-return (cons 0 loopy-result)))
+
+;; => (0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect i)
+       (finally-do (push 0 loopy-result)))
 @end lisp
 
 In general, you should not attempt to modify or use the value of @code{loopy-result}
-during the loop, as it is not guaranteed to have a correct value when
-efficiently building sequences.  For example, it is often faster to build a list
-in reverse instead of appending to its end.  For some commands, such as those in
+during the loop when it is used as the implied accumulation variable for a
+command, as it is not guaranteed to have a correct value when efficiently
+building sequences.  For example, it is often faster to build a list in reverse
+instead of appending to its end.  For some commands, such as those in
 @ref{Numeric Accumulation} and @ref{Generic Accumulation}, this does not matter.
 
 Be aware that explicitly named accumulation variables do not affect the implied
@@ -4435,8 +4478,11 @@ finalized.
        (finally-return loopy-result))
 @end lisp
 
-As noted in @ref{Special Macro Arguments}, the special macro argument @samp{finally-do} does not
-affect the return value of the loop.
+As noted in @ref{Special Macro Arguments}, the return value of Lisp code given in the special
+macro argument @samp{finally-do} does not affect the return value of the loop.
+However, @samp{finally-do} can modify the values of variables after the loop
+completes, including @code{loopy-result} (even when used as an implied accumulation
+variable).
 
 @lisp
 ;; => (0 1 2 3 4)
@@ -4446,6 +4492,9 @@ affect the return value of the loop.
          (leave))
        (finally-do 7))
 
+;; _Does not_ modify the then-current value of `loopy-result'
+;; returned by the `return' command:
+;;
 ;; => (4 3 2 1 0)
 (loopy (numbers i :to 10)
        (if (< i 5)
@@ -4453,7 +4502,25 @@ affect the return value of the loop.
          ;; Not finalized:
          (return loopy-result))
        (finally-do
+        ;; Affects what is stored in `loopy-result',
+        ;; but because of the `return' command,
+        ;; not what the macro actually returns.
         (cl-callf2 cons 22 loopy-result)))
+
+;; _Does_ modify the value of `loopy-result' returned by the macro:
+;;
+;; => (0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect loopy-result i)
+       (finally-do (push 0 loopy-result))
+       (finally-return loopy-result))
+
+;; _Does_ modify the value of `loopy-result' returned by the macro:
+;;
+;; => (0 1 2 3)
+(loopy (list i '(1 2 3))
+       (collect i)
+       (finally-do (push 0 loopy-result)))
 @end lisp
 
 As noted in @ref{Special Macro Arguments}, the special macro argument @samp{finally-return}
@@ -4940,7 +5007,7 @@ using the @code{let*} special form.
 This method recognizes all commands and their aliases in the user option
 @code{loopy-parsers}.
 
-@float Listing,org8d78e14
+@float Listing,orgf6ce5d7
 @lisp
 ;; => ((-9 -8 -7 -6 -5 -4 -3 -2 -1)
 ;;     (0)
@@ -5341,6 +5408,11 @@ method).
 Flags are applied in order.  If you specify @samp{(flags seq pcase)}, then @code{loopy}
 will use @code{pcase-let} for destructuring, not @code{seq-let}.
 
+@vindex loopy-default-flags
+If you wish to always use a flag, you can add that flag to the list
+@code{loopy-default-flags}.  These can be overridden by any flag given in the @samp{flag}
+special macro argument.
+
 The following flags are currently supported:
 
 @cindex pcase flag
@@ -5490,7 +5562,7 @@ between aliases and preferred names (which are the ones commonly used and listed
 first in this document).  We continue to use the word ``alias'' for its common
 definition rather than to suggest a difference in the code.
 
-@float Listing,org51fe987
+@float Listing,orgc46048a
 @lisp
 ;; => ("a" "b" "c" "d")
 (loopy (array i "abcd")


### PR DESCRIPTION
Use of the `prog1` was not allowing `finally-do` to modify the implied
return value of a loop stored in `loopy-result`.  Conceptually, an implied
`loopy-result` should not be different from an explicit `loopy-result` in this
context, outside of the variable value needing to be finalized.

The new expansion of the macro is still consistent with the example
expansion given in `loopy--expand-to-loop`.

Previously, one would've needed to use `finally-return` after the
`finally-do`:

```emacs-lisp
;; => (0 1 2 3)
(loopy (list i '(1 2 3))
       (collect loopy-result i)
       (finally-do (push 0 loopy-result))
       (finally-return loopy-result))
```

Now it works more like expected:

```emacs-lisp
;; => (0 1 2 3)
(loopy (list i '(1 2 3))
       (collect i)
       (finally-do (push 0 loopy-result)))
```