### PR TITLE
Increase needed Emacs version from 27.1 to 28.1.

### DIFF
--- a/.github/workflows/emacs-matrix-tests.yml
+++ b/.github/workflows/emacs-matrix-tests.yml
@@ -15,8 +15,6 @@ jobs:
     strategy:
       matrix:
         emacs-version:
-          # - '27.1'
-          - '27.2'
           # - '28.1'
           - '28.2'
           - '29.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 
 ### Breaking Changes
 
+- Loopy now requires at least Emacs version 28.1, increased from version 27.1
+  ([#446]).  This allows us to remove workarounds for missing features/fixes.
+
 - `set` now warns when it is not given a value ([#229]).  Currently, `(set VAR)`
   binds `VAR` to `nil`, but since this form is indistinguishable from a mistake,
   and since `nil` is a short word to write, this behavior is deprecated.
@@ -97,6 +100,7 @@ For Loopy Dash, see <https://github.com/okamsn/loopy-dash>.
 [#242]: https://github.com/okamsn/loopy/PR/242
 [#243]: https://github.com/okamsn/loopy/PR/243
 [#244]: https://github.com/okamsn/loopy/PR/244
+[#246]: https://github.com/okamsn/loopy/PR/246
 
 ## 0.14.0
 

--- a/README.org
+++ b/README.org
@@ -36,6 +36,8 @@ please let me know.
 
  _Recent breaking changes:_
  - Unreleased:
+   - Loopy now requires at least Emacs version 28.1, increased from version
+     27.1.
    - =set= now warns when it is not given a value.  In the future, it will
      signal an error.
    - ~loopy-command-parsers~ and ~loopy-aliases~ are deprecated in favor of

--- a/lisp/loopy.el
+++ b/lisp/loopy.el
@@ -6,7 +6,7 @@
 ;; Created: November 2020
 ;; URL: https://github.com/okamsn/loopy
 ;; Version: 0.14.0
-;; Package-Requires: ((emacs "27.1") (map "3.3.1") (seq "2.22") (compat "29.1.3") (stream "2.4.0"))
+;; Package-Requires: ((emacs "28.1") (map "3.3.1") (seq "2.22") (compat "29.1.3") (stream "2.4.0"))
 ;; Keywords: extensions
 ;; LocalWords:  Loopy's emacs Edebug
 


### PR DESCRIPTION
We keep working around missing features in the built-in version of `map.el` in
Emacs 27.  We also have workarounds in the code for older versions of Pcase,
such as `loopy--pcase-let-workaround`.  Increase the required version
so that we can start removing these things.