### PR TITLE
Don't use a completion check when `finally-return` is used.

### DIFF
--- a/lisp/loopy.el
+++ b/lisp/loopy.el
@@ -363,7 +363,12 @@ The function creates quoted code that should be used by a macro."
                       ;; completes to see whether we should return
                       ;; an early return value (the value of the `cl-block')
                       ;; or a possibly now-updated value of `loopy-result'.
-                      ,(when loopy--final-do
+                      ;;
+                      ;; We don't need to check whether it completed
+                      ;; when there is a `finally-return' because we
+                      ;; know that we are not using an implied return value.
+                      ,(when (and loopy--final-do
+                                  (not loopy--final-return))
                          `(setq ,loop-completed-var t))
                       ;; This can be overridden by any call to
                       ;; `cl-return-from'.


### PR DESCRIPTION
In PR #244, we added a completion test when using `finally-do` in case
the loop would have used `loopy-result` and maybe modified it in `finally-do`,
but the loop was apparently terminated early, in which case we
should have used the value captured by the `cl-block`.

When we added that, we incorrectly set the variable
when using `finally-do` even when we were using `finally-return`,
in which case the completion test in unneeded.