### PR TITLE
Remove Pcase workarounds for Emacs 27.

### DIFF
--- a/lisp/loopy-misc.el
+++ b/lisp/loopy-misc.el
@@ -418,19 +418,5 @@ KEY transforms those elements and ELEMENT."
       ('eq    `(memq   ,element ,list))
       (_ form))))
 
-(cl-defmacro loopy--pcase-let-workaround (variables form)
-  "Wrap FORM in a `let' with VARIABLES bound to nil on Emacs less than 28.
-
-Prior to Emacs 28, it was not guaranteed that `pcase-let' bound
-unmatched variables."
-  (declare (indent 1))
-  (static-if (< emacs-major-version 28)
-      `(let ,(mapcar (lambda (sym) `(,sym nil))
-                     variables)
-         ,(cons 'ignore variables)
-         ,form)
-    (ignore variables)
-    form))
-
 (provide 'loopy-misc)
 ;;; loopy-misc.el ends here


### PR DESCRIPTION
- In `loopy-destructure.el`, don't use methods other than `pcase-compile-patterns` for getting Pcase variables.  Now that we depend on at least Emacs 28.1, we can stop using the older method.

- Simplify `loopy--pcase-destructure-for-iteration` and `loopy--pcase-parse-for-destructuring-accumulation-command`.
  - Stop creating a capturing variable to use with the erroring case. Instead, use a generated symbol as the match condition. Create the erroring branch using the new function `loopy--pcase-make-erroring-branch`.

- Remove `loopy--pcase-let-workaround`.  This macro is no longer needed now that minimum Emacs version is 28.

- Revert `loopy-let*` back to a wrapper of (possible multiple uses of) `pcase`. Do this instead of calling `loopy--pcase-destructure-for-iteration` directly.

- Copy definition of `pcase--flip` instead of using it internally. In Emacs 30, we no longer need the functionality of `pcase--flip`.