### PR TITLE
Test Emacs 30.2 separately from the current release snapshot.

### DIFF
--- a/.github/workflows/emacs-matrix-tests.yml
+++ b/.github/workflows/emacs-matrix-tests.yml
@@ -18,6 +18,7 @@ jobs:
           # - '28.1'
           - '28.2'
           - '29.2'
+          - '30.2'
           - 'release-snapshot'
           # - 'snapshot'
     steps:


### PR DESCRIPTION
List 30.2 separately in `.github/workflows/emacs-matrix-tests.yml`.