### PR TITLE
Fix detecting destructured `with`-bound variables.

### DIFF
--- a/lisp/loopy-iter.el
+++ b/lisp/loopy-iter.el
@@ -389,7 +389,8 @@ Returns BODY without the `%s' argument."
                 ((= 1 (length binding)) (list (cl-first binding) nil))
                 (t                       binding)))
          (finally-do
-          (setq loopy--with-vars loopy-result))))
+          (setq loopy--with-vars (loopy--destructure-for-with-vars
+                                  loopy-result)))))
 
 
 (loopy-iter--def-special-processor finally-return

--- a/lisp/loopy-seq.el
+++ b/lisp/loopy-seq.el
@@ -85,9 +85,18 @@
   "Return a way to destructure BINDINGS as if by a `seq-let*'.
 
 Returns a list of two elements:
-1. The symbol `loopy-seq--seq-let*'.
-2. A new list of bindings."
-  (list 'loopy-seq--seq-let* bindings))
+1. A list of symbols being all the variables to be bound in BINDINGS.
+2. A function to be called with the code to be wrapped, which
+  should produce wrapped code appropriate for BINDINGS,
+  such as a `let*' form."
+  (loopy--pcase-destructure-for-with-vars
+   (cl-loop for b in bindings
+            for (var val) = b
+            collect (if (seqp var)
+                        `(,(loopy-seq--make-pcase-pattern var)
+                          ,val)
+                      b))
+   :error nil))
 
 (defmacro loopy-seq--seq-let* (bindings &rest body)
   "Bind variables in BINDINGS according via `seq-let' and `let'.

--- a/tests/pcase-tests.el
+++ b/tests/pcase-tests.el
@@ -112,3 +112,15 @@
   (should-not loopy--destructuring-for-with-vars-function)
   (should-not loopy--destructuring-for-iteration-function)
   (should-not loopy--destructuring-accumulation-parser))
+
+(ert-deftest pcase-with-var-destructured-still-detected ()
+  "Make sure destructured `with' variables are still detected by other commands.
+For example, make sure we don't see an error for incompatible accumulations
+since we are binding `acc' in `with'."
+  (should (= 45 (eval '(loopy (flag pcase)
+                              (with (`(,acc ,b) '(3 4)))
+                              (list i '(1 2 3))
+                              (sum acc i)
+                              (multiply acc i)
+                              (finally-return acc))
+                      t))))

--- a/tests/seq-tests.el
+++ b/tests/seq-tests.el
@@ -114,3 +114,15 @@
   (should-not loopy--destructuring-for-with-vars-function)
   (should-not loopy--destructuring-for-iteration-function)
   (should-not loopy--destructuring-accumulation-parser))
+
+(ert-deftest seq-with-var-destructured-still-detected ()
+  "Make sure destructured `with' variables are still detected by other commands.
+For example, make sure we don't see an error for incompatible accumulations
+since we are binding `acc' in `with'."
+  (should (= 45 (eval '(loopy (flag seq)
+                              (with ([acc b] '(3 4)))
+                              (list i '(1 2 3))
+                              (sum acc i)
+                              (multiply acc i)
+                              (finally-return acc))
+                      t))))


### PR DESCRIPTION
Fixes #252.  Fixes #259.

- In `loopy--pcase-destructure-for-iteration`:
  - Return list of single variable when given.  Previously, we were mistakenly
    returning the symbol instead of a list containing the symbol.
  - Prepend the `rest` variable in the `lambda` function with an underscore
    to silence a compiler warning.

- In `loopy--pcase-destructure-for-with-vars`:
  - Change the return value from a list containing the symbol `pcase-let*` and
    the list of variable bindings to a list containing a list of found variables
    as symbols and a function that receives an expression and produces wrapped
    code correctly binding the variables.
  - Add the argument `error`, like `loopy--pcase-destructure-for-with-vars`,
    so that we signal `loopy-bad-run-time-destructuring` when desired.

- In `loopy--process-special-arg-with` and
  `loopy-iter--process-special-arg-with`, set `loopy--with-vars`
  to the new output of `loopy--pcase-destructure-for-with-vars`
  instead of just the pairs given to the special macro argument.

- Update the documentation of `loopy--with-vars` to match the new output
  of `loopy--pcase-destructure-for-with-vars`.

- Update `loopy-seq--destructure-for-with-vars` and
  `loopy-pcase--destructure-for-with-vars` to match the new output
  of `loopy--pcase-destructure-for-with-vars`.

- Update `loopy--with-bound-p` to use the new output
  of `loopy--pcase-destructure-for-with-vars`.

- Update `loopy--expand-to-loop` to use the new output
  of `loopy--pcase-destructure-for-with-vars`.

- Add test `with-var-destructured-still-detected`
  to make sure accumulation commands properly detect destructured
  `with` variables.