### PR TITLE
Remove and clean-up old TODOs.

### DIFF
--- a/lisp/loopy-destructure.el
+++ b/lisp/loopy-destructure.el
@@ -542,28 +542,25 @@ MAP-OR-KEY-VARS is whether there are map or key variables."
 
 (defun loopy--seq-length= (seq n)
   "Check whether the length of SEQ is equal to N."
-  ;; TODO: Simplify when `stream.el' is updated and streams are no longer
-  ;; implemented as lists.  See also `loopy--seq-length>'.
   (cond
+   ((sequencep seq)
+    (length= seq n))
    ((streamp seq)
     ;; Avoid traversing long streams.
     (let ((s (seq-drop seq (1- n))))
       (and (not (stream-empty-p s))
            (stream-empty-p (stream-rest s)))))
-   ((listp seq)
-    (compat-call length= seq n))
    (t
     (= (seq-length seq) n))))
 
 (defun loopy--seq-length> (seq n)
   "Check whether the length of SEQ is greater than to N."
   (cond
-   ;; Test streams first, because version 2.3.0 of `stream.el' implements
-   ;; streams as lists. Take advantage of lazy evaluation of streams.
-   ((streamp seq) (not (stream-empty-p (seq-drop seq n))))
+   ((sequencep seq) (length> seq n))
+   ;; Take advantage of lazy evaluation of streams.
+   ((streamp seq)  (not (stream-empty-p (seq-drop seq n))))
    ;; `length>' only seems to matter for lists, based on its definition.
-   ((listp seq)   (compat-call length> seq n))
-   (t             (> (seq-length seq) n))))
+   (t              (> (seq-length seq) n))))
 
 (defun loopy--pcase-pat-positional-&seq-pattern (pos-vars opt-vars rest-var map-or-key-vars)
   "Build a pattern for the positional, `&optional', and `&rest' variables.

--- a/lisp/loopy-iter.el
+++ b/lisp/loopy-iter.el
@@ -321,11 +321,13 @@ Returns BODY without the `%s' argument."
                 name name)
        (loopy
         (accum-opt matching-args new-body)
+        (with (first-is-keyword nil))
         (listing expr body)
         (if (and (consp expr)
                  (let ((first (cl-first expr)))
                    (or (and (memq first loopy-iter--keywords-internal)
-                            (eq ,fn-sym (loopy--get-command-parser (cl-second expr) :error nil)))
+                            (eq ,fn-sym (loopy--get-command-parser (cl-second expr) :error nil))
+                            (setq first-is-keyword t))
                        (and (memq first loopy-iter--bare-names-internal)
                             (eq ,fn-sym (loopy--get-command-parser first :error nil))))))
             (collecting matching-args expr)
@@ -336,9 +338,7 @@ Returns BODY without the `%s' argument."
                         (let ((arg (car matching-args))
                               (arg-name)
                               (arg-value))
-                          ;; TODO: Probably a better way to do this that doesn't
-                          ;; involve checking twice.
-                          (if (memq (cl-first arg) loopy-iter-keywords)
+                          (if first-is-keyword
                               (loopy-setq (_ arg-name . arg-value) arg)
                             (loopy-setq (arg-name . arg-value) arg))
                           (ignore arg-name)


### PR DESCRIPTION
- In `lisp/loopy-commands.el`:
  - Remove TODO comment for `set-prev` command, stating to support when `back` is not know at compile time, as described in issue #194.  This was implemented.
    - Turn `loopy--distribute-list-elements`, `loopy--distribute-sequence-elements`, and `loopy--distribute-array-elements` into functions instead of macros.  Call using `apply` in their corresponding commands.
  - Remove old comments for `append` command.
    - Remove comment asking if there is a faster way to append.
  - For `loopy--parse-loop-command`, remove comment for allowing commands to return single instruction.  Always returning a list of instructions is more predictable.

- In `lisp/loopy-destructure.el`:
  - Remove mention of old implementation of streams for `loopy--seq-length=` and `loopy--seq-length>`.

- In `lisp/loopy-iter.el`:
  - In `loopy-iter--def-special-processor`, only check whether the form starts with a `loopy-iter-keyword` once.