### PR TITLE
Remove `loopy--apply-function`, which duplicates `byte-optimize-funcall`.

### DIFF
--- a/lisp/loopy-commands.el
+++ b/lisp/loopy-commands.el
@@ -1970,12 +1970,12 @@ you can use in the instructions:
               (loopy--check-accumulation-compatibility loopy--loop-name var 'generic cmd)
               `((loopy--accumulation-vars (,var nil))
                 (loopy--main-body
-                 (setq ,var ,(loopy--apply-function (cl-third args) val var)))))
+                 (setq ,var (funcall ,(cl-third args) ,val ,var)))))
   :implicit (progn
               (loopy--check-accumulation-compatibility loopy--loop-name var 'generic cmd)
               `((loopy--accumulation-vars (,var nil))
                 (loopy--main-body
-                 (setq ,var ,(loopy--apply-function (cl-second args) val var)))
+                 (setq ,var (funcall ,(cl-second args) ,val ,var)))
                 (loopy--implicit-return ,var))))
 
 ;;;;;;; Adjoin
@@ -2597,7 +2597,7 @@ by `cl-reduce'."
   :implicit `(,@(cond
                  ((loopy--with-bound-p var)
                   `((loopy--main-body
-                     (setq ,var ,(loopy--apply-function (cl-second args) var val)))))
+                     (setq ,var (funcall ,(cl-second args) ,var ,val)))))
                  (t
                   (let ((first-time (gensym "first-time")))
                     `((loopy--accumulation-vars (,var nil))
@@ -2606,12 +2606,12 @@ by `cl-reduce'."
                        (if ,first-time
                            (setq ,first-time nil
                                  ,var ,val)
-                         (setq ,var ,(loopy--apply-function (cl-second args) var val))))))))
+                         (setq ,var (funcall ,(cl-second args) ,var ,val))))))))
               (loopy--implicit-return ,var))
   :explicit `(,@(cond
                  ((loopy--with-bound-p var)
                   `((loopy--main-body
-                     (setq ,var ,(loopy--apply-function (cl-third args) var val)))))
+                     (setq ,var (funcall ,(cl-third args) ,var ,val)))))
                  (t
                   (let ((first-time (gensym "first-time")))
                     `((loopy--accumulation-vars (,var nil))
@@ -2620,7 +2620,7 @@ by `cl-reduce'."
                        (if ,first-time
                            (setq ,first-time nil
                                  ,var ,val)
-                         (setq ,var ,(loopy--apply-function (cl-third args) var val))))))))))
+                         (setq ,var (funcall ,(cl-third args) ,var ,val))))))))))
 
 ;;;;;;; Sum
 (loopy--defaccumulation sum

--- a/lisp/loopy-misc.el
+++ b/lisp/loopy-misc.el
@@ -355,17 +355,6 @@ If not, then it is possible that FORM is a variable."
            (eq (car form-or-symbol) 'function)
            (eq (car form-or-symbol) 'cl-function))))
 
-;; TODO: Byte optimization for `funcall' with a quoted argument
-;;       should expand to (FUNC ARGS...), so we shouldn't need
-;;       this function.
-(defun loopy--apply-function (func &rest args)
-  "Return an expansion to appropriately apply FUNC to ARGS.
-
-This expansion can apply FUNC directly or via `funcall'."
-  (if (loopy--quoted-form-p func)
-      `(,(loopy--get-function-symbol func) ,@args)
-    `(funcall ,func ,@args)))
-
 
 ;;;; Membership
 


### PR DESCRIPTION
This function checked whether the function form was quoted, in which case it returned a direct function call instead of using `funcall`.  However, the function `byte-optimize-funcall` already does that, so there is no point to `loopy--apply-function`.