### PR TITLE
Add GitHub Actions tests for compilation and add more Make targets for tests.

### DIFF
--- a/.github/workflows/emacs-matrix-tests.yml
+++ b/.github/workflows/emacs-matrix-tests.yml
@@ -57,4 +57,14 @@ jobs:
       run: emacs -batch --eval='(package-activate-all)' -l ert -l loopy-dash/tests/dash-tests.el -f ert-run-tests-batch-and-exit
     - name: Miscellaneous tests
       run: emacs -batch --eval='(package-activate-all)' -l ert -l tests/misc-tests.el -f ert-run-tests-batch-and-exit
+    - name: Byte Compilation test
+      run: emacs -batch --eval='(package-activate-all)' -f batch-byte-compile ~/.emacs.d/elpa/loopy*/*.el
+    - name: Native Compilation test
+      # if: (matrix.emacs-version > 29)
+      run: |
+        if [[ t = $(emacs -batch --eval="(prin1 (and (fboundp 'batch-native-compile) (funcall 'native-comp-available-p)))")  ]]; then
+            emacs -batch --eval='(package-activate-all)' -f batch-native-compile ~/.emacs.d/elpa/loopy*/*.el
+        else
+           echo Not running due to not having native compilation installed.
+        fi
     - run: echo "🍏 This job's status is ${{ job.status }}."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,27 @@
 EMACS ?= emacs
+USERDIR ?= ~/.emacs.d
+
+VERSION =
+.PHONY: version
+
+version:
+	@echo Getting version number from main file.
+	$(eval VERSION = $(shell $(EMACS) -Q -batch --eval="(progn (require 'lisp-mnt) (with-temp-buffer (insert-file-contents \"lisp/loopy.el\") (princ (or (lm-header \"package-version\") (lm-header \"version\")))))"))
+	@echo Package version is $(VERSION)
+
+tempdir:
+	@echo Creating temporary user directory.
+	$(eval USERDIR = $(shell mktemp --directory))
+	@echo Temporary user directory is "$(USERDIR)".
+	mkdir "$(USERDIR)/elpa"
+	mkdir "$(USERDIR)/eln-cache"
+
+.PHONY: test-install
+
+test-install: version tempdir
+	$(EMACS) -Q --init-directory="$(USERDIR)" -batch \
+		--eval="(progn (package-refresh-contents) \
+			  (package-install-file \"loopy-$(VERSION).tar\"))"
 
 .PHONY: tests
 
@@ -24,6 +47,23 @@ seq-tests:
 
 misc-tests:
 	$(EMACS) -Q -batch -l ert -l tests/load-path.el -l tests/misc-tests.el -f ert-run-tests-batch-and-exit
+
+.PHONY: byte-comp
+
+byte-comp-tests:
+	$(EMACS) -Q -batch -l ert -l tests/load-path.el -f batch-byte-compile ./lisp/*.el
+
+.PHONY: native-comp-tests
+
+# Native compilation seems to want the package to have already been
+# installed, so we do that using a temporary folder.
+native-comp-tests: version tempdir test-install
+	$(EMACS) -Q --init-directory="$(USERDIR)" -batch \
+		-l comp \
+		--eval="(package-activate-all)" \
+		--eval="(setq native-comp-eln-load-path (append native-comp-eln-load-path (list \"$(USERDIR)/eln-cache\")))" \
+		-f batch-native-compile \
+		$(USERDIR)/elpa/loopy-$(VERSION)/*.el
 
 .PHONY: all-tests
 
@@ -52,9 +92,7 @@ info:
 .PHONY: tar
 
 # Create Tar file for `package-install-file'
-tar: info
-	@echo Getting package version if not passed explicitly
-	$(eval VERSION ?= $(shell $(EMACS) -Q -batch --eval="(progn (require 'lisp-mnt) (with-temp-buffer (insert-file-contents \"lisp/loopy.el\") (princ (or (lm-header \"package-version\") (lm-header \"version\")))))"))
+tar: version info
 	@echo Package version is $(VERSION)
 	@echo ""
 	@echo "Making directory to hold package files"


### PR DESCRIPTION
- In `emacs-matrix-tests.yml`:
  - Create action using `batch-byte-compile`.

  - Create action using `batch-native-compile`.

In `Makefile`:
  - Move getting package version from recipe `tar` to new recipe `version`,
    which sets the new variable `VERSION`.

  - Create new variable `USERDIR`, which can be set by new recipe `tempdir`.
    Native compilation seems to want the package to already be installed,
    so we set up a temporary directory to install the package into.

  - Create new recipe `test-install` for testing installing the tar file
    generated by the recipe `tar`.

  - Create new recipe `byte-comp-tests`, which byte compiles the Lisp files
    and puts the ELC files beside them.

  - Create new recipe `native-comp-tests`, which byte compiles the Lisp files
    and puts the ELN files into a temporary user directory.