### PR TITLE
Add more `declare` forms to functions.  Improve things to make this easier.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,20 @@ version:
 	$(eval VERSION = $(shell $(EMACS) -Q -batch --eval="(progn (require 'lisp-mnt) (with-temp-buffer (insert-file-contents \"lisp/loopy.el\") (princ (or (lm-header \"package-version\") (lm-header \"version\")))))"))
 	@echo Package version is $(VERSION)
 
+TEMPDIR =
+.PHONY: tempdir
+
 tempdir:
 	@echo Creating temporary user directory.
-	$(eval USERDIR = $(shell mktemp --directory))
-	@echo Temporary user directory is "$(USERDIR)".
-	mkdir "$(USERDIR)/elpa"
-	mkdir "$(USERDIR)/eln-cache"
+	$(eval TEMPDIR = $(shell mktemp --directory))
+	@echo Temporary user directory is "$(TEMPDIR)".
+	mkdir "$(TEMPDIR)/elpa"
+	mkdir "$(TEMPDIR)/eln-cache"
 
 .PHONY: test-install
 
 test-install: version tempdir
-	$(EMACS) -Q --init-directory="$(USERDIR)" -batch \
+	$(EMACS) -Q --init-directory="$(TEMPDIR)" -batch \
 		--eval="(progn (package-refresh-contents) \
 			  (package-install-file \"loopy-$(VERSION).tar\"))"
 
@@ -48,22 +51,27 @@ seq-tests:
 misc-tests:
 	$(EMACS) -Q -batch -l ert -l tests/load-path.el -l tests/misc-tests.el -f ert-run-tests-batch-and-exit
 
-.PHONY: byte-comp
-
-byte-comp-tests:
-	$(EMACS) -Q -batch -l ert -l tests/load-path.el -f batch-byte-compile ./lisp/*.el
-
 .PHONY: native-comp-tests
 
-# Native compilation seems to want the package to have already been
-# installed, so we do that using a temporary folder.
-native-comp-tests: version tempdir test-install
-	$(EMACS) -Q --init-directory="$(USERDIR)" -batch \
+native-comp-tests:
+	$(EMACS) -Q -batch -l ert -l tests/load-path.el -l tests/misc-tests.el -f ert-run-tests-batch-and-exit
+
+.PHONY: byte-comp
+
+byte-comp:
+	$(EMACS) -Q -batch -l ert -l tests/load-path.el -f batch-byte-compile ./lisp/*.el
+
+.PHONY: native-comp
+
+# native-comp:
+# 	$(EMACS) -Q -batch -l ert -l tests/load-path.el -f batch-native-compile ./lisp/*.el
+native-comp: version tempdir test-install
+	$(EMACS) -Q --init-directory="$(TEMPDIR)" -batch \
 		-l comp \
 		--eval="(package-activate-all)" \
-		--eval="(setq native-comp-eln-load-path (append native-comp-eln-load-path (list \"$(USERDIR)/eln-cache\")))" \
+		--eval="(setq native-comp-eln-load-path (append native-comp-eln-load-path (list \"$(TEMPDIR)/eln-cache\")))" \
 		-f batch-native-compile \
-		$(USERDIR)/elpa/loopy-$(VERSION)/*.el
+		$(TEMPDIR)/elpa/loopy-$(VERSION)/*.el
 
 .PHONY: all-tests
 

--- a/lisp/loopy-commands.el
+++ b/lisp/loopy-commands.el
@@ -105,6 +105,11 @@ CORRECT is a list of valid keywords.
 Any keyword not in CORRECT is considered invalid.  Any element
 not in a keyword position that is not a keyword is invalid.  If
 LIST does not contain an even number of elements, it is invalid."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons cons) boolean))
+           )
   ;; `cl-loop' is broken for this use-case. See Emacs bug #72753.
   (let ((length 0))
     (let ((this-pos nil))
@@ -124,6 +129,10 @@ LIST does not contain an even number of elements, it is invalid."
   "Parse the `at' command as (at &rest COMMANDS).
 
 These commands affect other loops higher up in the call list."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (loopy--check-target-loop-name target-loop)
   (let ((loopy--loop-name target-loop)
         (loopy--in-sub-level t))
@@ -137,6 +146,10 @@ These commands affect other loops higher up in the call list."
 
 Unlike the `sub-loop' command, this command is not specially
 handled by `loopy-iter'."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   `((loopy--main-body ,(macroexpand `(loopy ,@body)))))
 
 ;;;;; Genereric Evaluation
@@ -146,6 +159,10 @@ handled by `loopy-iter'."
 
 - VAR is the variable to assign.
 - VALS are the values to assign to VAR."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let* ((value-selector (gensym "set-value-selector-"))
          (arg-length (length vals)))
     (cl-case arg-length
@@ -202,6 +219,10 @@ This command records the value of VAL at the end of the cycle,
 not when the command is run.
 
 This command does not wait for VAL to change before updating VAR."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (if (not (numberp back))
       ;; When we don't know ahead of time how far back we need to go, we have to
       ;;  use a queue.  This code is adapted from Irreal's blog
@@ -269,6 +290,10 @@ This command does not wait for VAL to change before updating VAR."
 BODY is one or more commands to be grouped by a `progn' form.
 This command is suitable for using as the first sub-command in an
 `if' command."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((loopy--in-sub-level t))
     (loopy--bind-main-body (progn-body rest)
         (loopy--parse-loop-commands body)
@@ -282,6 +307,11 @@ This command is suitable for using as the first sub-command in an
 
 Expressions are normal Lisp expressions, which are inserted into
 the loop literally (not even in a `progn')."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (mapcar (lambda (expr) (list 'loopy--main-body expr))
           expressions))
 
@@ -294,6 +324,10 @@ the loop literally (not even in a `progn')."
 - CONDITION is a Lisp expression.
 - IF-TRUE is the first sub-command of the `if' command.
 - IF-FALSE are all the other sub-commands."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((loopy--in-sub-level t))
     (loopy--bind-main-body (if-true-main-body true-rest)
         (loopy--parse-loop-command if-true)
@@ -315,6 +349,10 @@ loop commands.
 
 The Lisp expression and the loopy-body instructions from each
 command are inserted into a `cond' special form."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((loopy--in-sub-level t)
         (cond-body nil)
         (rest-instructions nil))
@@ -330,6 +368,10 @@ command are inserted into a `cond' special form."
 ;;;;;; When
 (cl-defun loopy--parse-when-command ((_ condition &rest body))
   "Parse `when' as (when CONDITION [COMMANDS])."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((loopy--in-sub-level t))
     (loopy--bind-main-body (main other)
         (loopy--parse-loop-commands body)
@@ -339,6 +381,10 @@ command are inserted into a `cond' special form."
 ;;;;;; Unless
 (cl-defun loopy--parse-unless-command ((_ condition &rest body))
   "Parse `unless' as (unless CONDITION [COMMANDS])."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((loopy--in-sub-level t))
     (loopy--bind-main-body (main other)
         (loopy--parse-loop-commands body)
@@ -486,6 +532,10 @@ instructions:
                 (when other-vals
                   '(&rest other-vals)))))
        ,doc-string
+       (declare (important-return-value t)
+                ;; TODO: `ftype' for `cl-defun'?
+                ;; (ftype (function (cons) cons))
+                )
 
        (when loopy--in-sub-level
          ;; Warn with the used name and the true name.
@@ -560,6 +610,8 @@ iteration command.  The supported keywords are:
 - `:test-given' (whether `:test' was given)
 
 CMD is the command usage for error reporting."
+  (declare (important-return-value t)
+           (ftype (function (cons &optional symbol) cons)))
 
   (loopy--plist-bind ( :from from :upfrom upfrom :downfrom downfrom
                        :to to :upto upto :downto downto
@@ -627,6 +679,9 @@ CMD is the command usage for error reporting."
   "Distribute the elements of the ARRAYS into an array of lists.
 
 For example, [1 2] and [3 4] gives [(1 3) (1 4) (2 3) (2 4)]."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (&rest t) cons)))
   (let ((vars (cl-loop for _ in arrays
                        collect (gensym "array-var-")))
         (reverse-order (reverse arrays)))
@@ -822,6 +877,9 @@ and is a value."
   "Distribute the elements of LISTS into a list of lists.
 
 For example, (1 2) and (3 4) would give ((1 3) (1 4) (2 3) (2 4))."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (&rest t) cons)))
 
   (let ((vars (cl-loop for _ in lists
                        collect (gensym "list-var-")))
@@ -891,6 +949,10 @@ vector using the library `map.el'.
 
 NAME is used for reporting errors in case of aliases.
 If UNIQUE, filter out values for duplicated keys."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (when loopy--in-sub-level
     (loopy--signal-bad-iter name 'map))
   (loopy--instr-let-var* ((value-holder `(map-pairs ,val)))
@@ -935,6 +997,10 @@ Uses `map-elt' as a `setf'-able place, iterating through the
 map's keys.
 
 NAME is used for reporting errors in case of aliases."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (when loopy--in-sub-level
     (loopy--signal-bad-iter name 'map-ref))
   (loopy--instr-let-var* ((key-list `(map-keys ,val)))
@@ -1078,6 +1144,10 @@ This is for decreasing indices.
 VAR-OR-COUNT is a variable name or an integer.  Optional COUNT is
 an integer, to be used if a variable name is provided.
 NAME is the name of the command."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (when loopy--in-sub-level
     (loopy--signal-bad-iter name 'cycle))
   ;; TODO: If we know at compile-time that num-steps is 1,
@@ -1099,6 +1169,9 @@ NAME is the name of the command."
   "Distribute the elements of SEQUENCES into a vector of lists.
 
 For example, [1 2] and (3 4) give [(1 3) (1 4) (2 3) (2 4)]."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (&rest t) cons)))
   (let ((vars (cl-loop for _ in sequences
                        collect (gensym "seq-var-")))
         (reverse-order (reverse sequences))
@@ -1176,6 +1249,9 @@ distributed using the function `loopy--distribute-seq-elements'."
   "Distribute the elements of SEQUENCES into a vector of lists.
 
 For example, [1 2] and (3 4) give [(1 3) (1 4) (2 3) (2 4)]."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (&rest t) cons)))
   (let ((vars (cl-loop for _ in sequences
                        collect (gensym "seq-var-")))
         (reverse-order (reverse sequences)))
@@ -1564,6 +1640,10 @@ command.
   the loop, such as `collect'.
 - `boolean-thereis' is only used by the `thereis' command.
 - `boolean-always-never' is only used by the `always' and `never' commands."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function (symbol symbol symbol cons) t)))
+
   (unless (memq category loopy--known-accumulation-categories)
     (signal 'loopy-bad-accum-category (list category)))
 
@@ -1590,6 +1670,8 @@ keep track of a list's last link.
 
 This function uses `loopy--accumulation-list-end-vars' to store
 end-tracking variables."
+  (declare (important-return-value t)
+           (ftype (function (symbol symbol) symbol)))
   (let ((key (cons loop var)))
     (or (alist-get key loopy--accumulation-list-end-vars nil nil #'equal)
         ;; `map-put!' would fail here, since the association doesn't exist
@@ -1609,6 +1691,8 @@ commands like `collect'.
 For efficiency, accumulation commands use references to track the
 end location of the results list.  For larger lists, this is much
 more efficient than repeatedly traversing the list."
+  (declare (important-return-value t)
+           (ftype (function (symbol symbol) cons)))
   ;; End tracking is a bit slower than `nconc' for short lists, but much faster
   ;; for longer lists.
   (let ((last-link (loopy--get-accumulation-list-end-var loopy--loop-name var)))
@@ -1639,6 +1723,20 @@ accumulation commands like `adjoin'.
 For efficiency, accumulation commands use references to track the
 end location of the results list.  For larger lists, this is much
 more efficient than repeatedly traversing the list."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (symbol symbol) cons)
+           ;;            (function (symbol symbol (member :test) (function (t t) boolean)) cons)
+           ;;            (function (symbol symbol (member :key) (function (t) t)) cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :key) (function (t) t))
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :test) (function (t t) boolean))
+           ;;                      cons)))
+           )
   ;; End tracking is a bit slower than `nconc' for short lists, but much faster
   ;; for longer lists.
   (let ((last-link (loopy--get-accumulation-list-end-var loopy--loop-name var)))
@@ -1677,6 +1775,8 @@ accumulation commands like `append' and `nconc'.
 For efficiency, accumulation commands use references to track the
 end location of the results list.  For larger lists, this is much
 more efficient than repeatedly traversing the list."
+  (declare (important-return-value t)
+           (ftype (function (symbol symbol &optional boolean) cons)))
   ;; End tracking is a bit slower than `nconc' for short lists, but much faster
   ;; for longer lists.
   (let ((last-link (loopy--get-accumulation-list-end-var loopy--loop-name var))
@@ -1708,6 +1808,43 @@ This is used in accumulation commands like `union' and `nunion'.
 For efficiency, accumulation commands use references to track the
 end location of the results list.  For larger lists, this is much
 more efficient than repeatedly traversing the list."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (symbol symbol) cons)
+           ;;            (function (symbol symbol (member :test) (function (t t) boolean)) cons)
+           ;;            (function (symbol symbol (member :key) (function (t) t)) cons)
+           ;;            (function (symbol symbol (member :destructive) boolean) cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :destructive) boolean)
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :destructive) boolean
+           ;;                        (member :key) (function (t) t))
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :destructive) boolean
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :key) (function (t) t))
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :destructive) boolean
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :test) (function (t t) boolean))
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :destructive) boolean
+           ;;                        (member :test) (function (t t) boolean))
+           ;;                      cons)
+           ;;            (function ( symbol symbol
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :destructive) boolean)
+           ;;                      cons)))
+           )
   ;; End tracking is a bit slower than `nconc' for short
   ;; lists, but much faster for longer lists.
   (let ((last-link (loopy--get-accumulation-list-end-var loopy--loop-name var)))
@@ -1738,7 +1875,7 @@ more efficient than repeatedly traversing the list."
                              ,last-link (last ,var))))))))))))
 
 ;;;;;; Test Methods
-(cl-defun loopy--get-union-test-method (var &key key test)
+(cl-defun loopy--get-union-test-method (var &key test key)
   "Get a function testing for values in VAR in `union' and `nunion'.
 
 This function is fed to `cl-remove-if' or `cl-delete-if'.  See
@@ -1746,6 +1883,21 @@ the definitions of those commands for more context.
 
 TEST is use to check for equality (default `equal').  KEY modifies
 the inputs to test."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (symbol) cons)
+           ;;            (function (symbol (member :test) (function (t t) boolean)) cons)
+           ;;            (function (symbol (member :key) (function (t) t)) cons)
+           ;;            (function ( symbol
+           ;;                        (member :test) (function (t t) boolean)
+           ;;                        (member :key) (function (t) t))
+           ;;                      cons)
+           ;;            (function ( symbol
+           ;;                        (member :key) (function (t) t)
+           ;;                        (member :test) (function (t t) boolean))
+           ;;                      cons)))
+           )
   ;;  KEY applies to the value being tested as well as the elements in the list.
   (cl-with-gensyms (arg)
     `(lambda (,arg)
@@ -1765,6 +1917,8 @@ Then entire plist is passed to the constructor found in
 `loopy--optimized-accum' is a fake function.  It only used in a
 second pass of macro expansion."
   ;; Data is quoted to prevent recursive macro expansion.
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (let ((plist (cl-second arg)))
     (loopy--plist-bind (:name name :loop loop :opt-accum-fn fn)
         plist
@@ -1776,19 +1930,25 @@ second pass of macro expansion."
            `((loopy--at-instructions (,loop ,@(remq nil other-instrs)))))
           (macroexp-progn main-body))))))
 
-(cl-defun loopy--update-accum-place-count (loop var place &optional (value 1))
+(defun loopy--update-accum-place-count (loop var place &optional value)
   "Keep track of where things are being placed.
 
 LOOP is the current loop.  VAR is the accumulation variable.
-PLACE is one of `start' or `end'.  VALUE is the integer by which
-to increment the count (default 1)."
+PLACE is one of `start' or `end'.
+
+VALUE is used when `accum-opt' biases a location to be favored."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           (ftype (function ( symbol symbol symbol
+                              &optional (member 1 1.0 1.0e+INF))
+                            t)))
   (loopy--check-target-loop-name loop)
   (loopy--check-position-name place)
   (cl-symbol-macrolet ((loop-map (map-elt loopy--accumulation-places loop)))
     (unless (map-elt loop-map var)
       (setf (map-elt loop-map var)
             (list (cons 'start 0) (cons 'end 0))))
-    (cl-incf (map-elt (map-elt loop-map var) place) value)))
+    (cl-incf (map-elt (map-elt loop-map var) place) (or value 1))))
 
 ;;;;;; Commands
 (cl-defmacro loopy--defaccumulation (name
@@ -1835,7 +1995,10 @@ you can use in the instructions:
 - `val' is the value to be accumulated.
 - `opts' is the list of optional arguments that were given.  These are the
   arguments after those described as basic by NUM-ARGS."
-  (declare (indent defun) (doc-string 2))
+  (declare (indent defun)
+           (doc-string 2)
+           (side-effect-free nil)
+           (important-return-value nil))
 
   (unless explicit
     (error "Key-argument `explicit' not optional"))
@@ -1858,6 +2021,10 @@ you can use in the instructions:
   `(cl-defun ,(intern (format "loopy--parse-%s-command" name))
        ((&whole cmd name &rest parser-args))
      ,doc-string
+     (declare (important-return-value t)
+              ;; TODO: `ftype' for `cl-defun'
+              ;; (ftype (function (cons) cons))
+              )
      ,(let ((explicit-num-args num-args)
             (implicit-num-args (1- num-args))
             (explicit-category)
@@ -1981,6 +2148,8 @@ you can use in the instructions:
 ;;;;;;; Adjoin
 (defun loopy--construct-accum-adjoin (plist)
   "Construct optimized accumulation for `adjoin' from PLIST."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val
                        :test test :key key :at pos)
       plist
@@ -2064,6 +2233,8 @@ you can use in the instructions:
 ;;;;;;; Append
 (defun loopy--construct-accum-append (plist)
   "Produce accumulation code for `append' from PLIST."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop
                        :var var :val val
                        :at (pos 'end))
@@ -2126,6 +2297,8 @@ you can use in the instructions:
 ;;;;;;; Collect
 (defun loopy--construct-accum-collect (plist)
   "Construct an optimized `collect' accumulation from PLIST."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val :at (pos 'end))
       plist
     `((loopy--accumulation-vars (,var nil))
@@ -2191,6 +2364,8 @@ you can use in the instructions:
   "Create accumulation code for `concat' from PLIST.
 
 This function is called by `loopy--expand-optimized-accum'."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val
                        :at (pos 'end))
       plist
@@ -2393,6 +2568,8 @@ EXPR is the value to bind to VAR."
 ;;;;;;; Nconc
 (defun loopy--construct-accum-nconc (plist)
   "Create accumulation code for PLIST."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind (:cmd cmd :loop loop :var var :val val :at (pos 'end))
       plist
     (map-let (('start start)
@@ -2455,6 +2632,8 @@ EXPR is the value to bind to VAR."
   "Create accumulation code for `nunion' from PLIST.
 
 This function is used by `loopy--expand-optimized-accum'."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val :at (pos 'end)
                        :key key :test test)
       plist
@@ -2557,6 +2736,8 @@ This function is used by `loopy--expand-optimized-accum'."
   "Parse the `prepend' command as (append VAR VAL :at start).
 
 ARG is the entire loop command."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (unless (member (length arg) '(2 3))
     (error "`%s': Wrong number of arguments: %s"
            (car arg) arg))
@@ -2569,6 +2750,8 @@ ARG is the entire loop command."
   "Parse the `push-into' command as (collect VAR VAL :at start).
 
 ARG is the entire loop command."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (unless (member (length arg) '(2 3))
     (error "`%s': Wrong number of arguments: %s"
            (car arg) arg))
@@ -2643,6 +2826,8 @@ by `cl-reduce'."
   "Create accumulation code for `nunion' from PLIST.
 
 This function is used by `loopy--expand-optimized-accum'."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val :at (pos 'end)
                        :key key :test test)
       plist
@@ -2745,6 +2930,8 @@ This function is used by `loopy--expand-optimized-accum'."
   "Create accumulation code for `vconcat' from PLIST.
 
 This function is called by `loopy--expand-optimized-accum'."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--plist-bind ( :cmd cmd :loop loop :var var :val val
                        :at (pos 'end))
       plist
@@ -2861,12 +3048,24 @@ returned."
 ;;;;;; Leave
 (cl-defun loopy--parse-leave-command (_)
   "Parse the `leave' command."
+  (declare (side-effect-free t)
+           (pure nil) ; loop name
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((tag-name (loopy--produce-non-returning-exit-tag-name loopy--loop-name)))
     `((loopy--non-returning-exit-used ,tag-name)
       (loopy--main-body (throw (quote ,tag-name) t)))))
 
 (cl-defun loopy--parse-leave-from-command ((_ target-loop))
   "Parse the `leave-from' command."
+  (declare (side-effect-free nil) ; Name check.
+           (pure nil)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (loopy--check-target-loop-name target-loop)
   (let ((tag-name (loopy--produce-non-returning-exit-tag-name target-loop)))
     `((loopy--at-instructions (,target-loop
@@ -2876,6 +3075,12 @@ returned."
 ;;;;;; Return
 (cl-defun loopy--parse-return-command ((_ &rest values))
   "Parse the `return' command as (return [VALUES])."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (pure nil) ; loop name
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   `((loopy--main-body
      (cl-return-from ,loopy--loop-name
        ,(cond
@@ -2885,7 +3090,12 @@ returned."
 
 (cl-defun loopy--parse-return-from-command ((_ loop-name &rest values))
   "Parse the `return-from' command as (return-from LOOP-NAME [VALUES])."
-  ;; (loopy--check-target-loop-name loop-name)
+  (declare (side-effect-free nil) ; Name check.
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
+  (loopy--check-target-loop-name loop-name)
   `((loopy--main-body
      (cl-return-from ,loop-name
        ,(cond
@@ -2896,12 +3106,23 @@ returned."
 ;;;;;; Skip
 (cl-defun loopy--parse-skip-command (_)
   "Parse the `skip' loop command."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (pure nil) ; loop name
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((tag-name (loopy--produce-skip-tag-name loopy--loop-name)))
     `((loopy--skip-used ,tag-name)
       (loopy--main-body (throw (quote ,tag-name) t)))))
 
 (cl-defun loopy--parse-skip-from-command ((_ target-loop))
   "Parse the `skip-from' loop command as (skip-from LOOP-NAME)."
+  (declare (side-effect-free nil) ; Name check
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (loopy--check-target-loop-name target-loop)
   (let ((tag-name (loopy--produce-skip-tag-name target-loop)))
     `((loopy--at-instructions (,target-loop
@@ -2916,6 +3137,11 @@ Stop the loop when CONDITION is nil.
 
 CONDITION is a required condition.  CONDITIONS is the remaining optional
 conditions."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (when conditions
     (warn "`loopy': `while' will only support one argument in the future.
 To keep the old behavior, wrap multiple conditions with `and'."))
@@ -2935,6 +3161,11 @@ Stop the loop when CONDITION is non-nil.
 
 CONDITION is a required condition.  CONDITIONS is the remaining optional
 conditions."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (when conditions
     (warn "`loopy': `until' will only support one argument in the future.
 To keep the old behavior, wrap multiple conditions with `and'."))
@@ -2954,6 +3185,11 @@ To keep the old behavior, wrap multiple conditions with `and'."))
 
 NAME is `while' or `until'.  CONDITION is a required condition.
 CONDITIONS is the remaining optional conditions."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (let ((tag-name (loopy--produce-non-returning-exit-tag-name loopy--loop-name))
         (condition (if (zerop (length conditions))
                        condition
@@ -2973,6 +3209,8 @@ Return a list of instructions for naming these `setf'-able places.
 
 VAR are the variables into to which to destructure the value of
 VALUE-EXPRESSION."
+  (declare (important-return-value t)
+           (ftype (function ((or symbol sequence) t) cons)))
   (let ((destructurings
          (loopy--destructure-generalized-sequence var value-expression))
         (instructions nil))
@@ -2990,6 +3228,8 @@ Returns a list.  The elements are:
    in VAL.
 2. A list of variables which exist outside of this expression and
    need to be `let'-bound."
+  (declare (important-return-value t)
+           (ftype (function ((or symbol sequence) t) cons)))
   (let ((res (loopy--pcase-destructure-for-iteration `(loopy ,var) val :error t)))
     (if (null (cl-second res))
         (signal 'loopy-destructure-vars-missing (list var val))
@@ -3003,6 +3243,8 @@ Returns a list.  The elements are:
    in VAL.
 2. A list of variables which exist outside of this expression and
    need to be `let'-bound."
+  (declare (important-return-value t)
+           (ftype (function ((or symbol sequence) t) cons)))
   (pcase-let ((`(,expr ,vars)
                (funcall (or loopy--destructuring-for-iteration-function
                             #'loopy--destructure-for-iteration-default)
@@ -3021,6 +3263,8 @@ variables (`setf'-able places).  For that, see the function
 
 Return a list of instructions for initializing the variables and
 destructuring into them in the loop body."
+  (declare (important-return-value t)
+           (ftype (function ((or symbol sequence) t) cons)))
   (if (symbolp var)
       `((loopy--iteration-vars (,var nil))
         (loopy--main-body (setq ,var ,value-expression)))
@@ -3041,6 +3285,8 @@ Return a list of instructions for initializing the variables and
 destructuring into them in the loop body.
 
 A wrapper around `loopy--destructure-for-iteration-command'."
+  (declare (important-return-value t)
+           (ftype (function ((or symbol sequence) t) cons)))
   (cl-loop
    for binding in (loopy--destructure-for-iteration-command var value-expression)
    if (eq (car binding) 'loopy--iteration-vars)
@@ -3057,6 +3303,10 @@ Unlike `loopy--destructure-for-iteration-command', this function
 does destructuring and returns instructions.
 
 NAME is the name of the command.  VAR is a variable name.  VAL is a value."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (loopy--pcase-parse-for-destructuring-accumulation-command
    `(,name (loopy ,var) ,val ,@args)
    :error t))
@@ -3069,6 +3319,8 @@ To allow for some flexibility in the command parsers, any nil
 instructions are removed.
 
 This function gets the parser, and passes the command to that parser."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (let* ((parser (loopy--get-command-parser (cl-first command)))
          (instructions (remq nil (funcall parser command))))
     (or instructions
@@ -3079,12 +3331,19 @@ This function gets the parser, and passes the command to that parser."
   "Parse commands in COMMAND-LIST via `loopy--parse-loop-command'.
 Return a single list of instructions in the same order as
 COMMAND-LIST."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (mapcan #'loopy--parse-loop-command command-list))
 
 (cl-defun loopy--get-command-parser (command-name &key (error t))
   "Get the parsing function for COMMAND-NAME.
 
 Failing that, an error is signaled when ERROR is non-nil."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (symbol (member :error) boolean) function)
+           ;;            (function (symbol) function)))
+           )
   (or (map-elt loopy--parsers-internal command-name)
       (when error
         (signal 'loopy-unknown-command (list command-name)))))

--- a/lisp/loopy-destructure.el
+++ b/lisp/loopy-destructure.el
@@ -45,6 +45,10 @@
 ;; This better allows for things to change in the future.
 (defun loopy--var-ignored-p (var)
   "Return whether VAR should be ignored for destructuring."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (pure t)
+           (ftype (function (symbol) boolean)))
   (and (symbolp var)
        (eq (aref (symbol-name var) 0) ?_)))
 
@@ -53,215 +57,215 @@
                                         &aux  &map)
   "Symbols affecting how following elements destructure.")
 
-;; Having a single function for all categories allows us to have most of the
-;; ordering rules in once place.
-(defconst loopy--get-var-groups-cache (make-hash-table :test 'equal :size 300)
-  "Cache of variable groups in a pattern.
-See also the function `loopy--get-var-groups'.")
-
 (defun loopy--get-var-groups (var-seq)
   "Return the alist of variable groups in sequence VAR-SEQ.
 Type is one of `list' or `array'."
-  (or (gethash var-seq loopy--get-var-groups-cache nil)
-      (let* ((is-seq)
-             (whole-var) (processing-whole)
-             (pos-var)
-             (opt-var) (processing-opts)
-             (rest-var) (processing-rest) (dotted-rest-var)
-             (key-var) (processing-keys) (allow-other-keys)
-             (map-var) (processing-maps)
-             (aux-var) (processing-auxs)
-             (proper-list-p (proper-list-p var-seq))
-             (type (cl-etypecase var-seq
-                     (list 'list)
-                     (array 'array)))
-             (improper-list (and (eq type 'list)
-                                 (not proper-list-p)))
-             (remaining-seq (if improper-list
-                                (cl-copy-list var-seq)
-                              (copy-sequence var-seq))))
+  (declare (important-return-value t)
+           (pure t)
+           (ftype (function (sequence) cons)))
+  (let ((var-is-list nil))
+    (cond
+     ((listp var-seq)
+      (setq var-is-list t))
+     ((not (arrayp var-seq))
+      (error "Not array nor list: `%S'" var-seq)))
+    (let* ((is-seq)
+           (whole-var) (processing-whole)
+           (pos-var)
+           (opt-var) (processing-opts)
+           (rest-var) (processing-rest) (dotted-rest-var)
+           (key-var) (processing-keys) (allow-other-keys)
+           (map-var) (processing-maps)
+           (aux-var) (processing-auxs)
+           (remaining-seq (if var-is-list
+                              (if (proper-list-p var-seq)
+                                  ;; proper list, no dotted item
+                                  var-seq
+                                ;; Otherwise, copy improper list,
+                                ;; set `rest-var' to dotted item,
+                                ;; and return copied list sans dotted item
+                                ;; in proper form.
+                                (let ((cp (cl-copy-list var-seq)))
+                                  (cl-shiftf dotted-rest-var
+                                             (cdr (last cp))
+                                             nil)
+                                  cp))
+                            ;; If not a list, convert from array into list.
+                            (append var-seq nil))))
 
-        (when improper-list
-          (cl-shiftf dotted-rest-var
-                     (cdr (last remaining-seq))
-                     nil))
+      (cl-flet ((missing-after (seq) (or (null seq)
+                                         (memq (cl-first seq)
+                                               loopy--destructure-symbols)))
+                (stop-processing () (setq processing-whole nil
+                                          processing-opts nil
+                                          processing-rest nil
+                                          processing-keys nil
+                                          processing-maps nil)))
+        (cl-loop
+         for (first . rest) on remaining-seq
+         do
+         (pcase first
+           ;; Since `&seq' must be first, we could check for it outside of
+           ;; processing, but we keep it with the other processing for
+           ;; consistency.
+           ('&seq             (cond
+                               ((or is-seq whole-var pos-var opt-var rest-var key-var
+                                    allow-other-keys aux-var map-var)
+                                (signal 'loopy-&seq-bad-position (list var-seq)))
+                               ((seq-empty-p rest)
+                                (signal 'loopy-bad-desctructuring
+                                        (list var-seq)))
+                               (t
+                                (stop-processing)
+                                (setq is-seq t))))
+           ('&whole           (cond
+                               ;; Make sure there is a variable named.
+                               ((missing-after rest)
+                                (signal 'loopy-&whole-missing (list var-seq)))
+                               ;; Make sure `&whole' is before all else.
+                               ((or whole-var pos-var opt-var rest-var key-var
+                                    allow-other-keys aux-var map-var)
+                                (signal 'loopy-&whole-bad-position (list var-seq)))
+                               (t
+                                (stop-processing)
+                                (setq processing-whole t))))
 
-        (cl-flet ((missing-after (seq) (or (seq-empty-p seq)
-                                           (memq (seq-elt seq 0)
-                                                 loopy--destructure-symbols)))
-                  (stop-processing () (setq processing-whole nil
-                                            processing-opts nil
-                                            processing-rest nil
-                                            processing-keys nil
-                                            processing-maps nil)))
+           ('&optional        (cond
+                               ((missing-after rest)
+                                (signal 'loopy-&optional-missing
+                                        (list var-seq)))
+                               ;; Make sure `&optional' does not occur after
+                               ;; `&rest'.
+                               ((or opt-var rest-var key-var map-var aux-var)
+                                (signal 'loopy-&optional-bad-position
+                                        (list var-seq)))
+                               (t
+                                (stop-processing)
+                                (setq processing-opts t))))
 
-          ;; Use `seq' functions to support arrays now and maybe other things later.
-          (while (not (seq-empty-p remaining-seq))
-            (seq-let [first &rest rest]
-                remaining-seq
-              (pcase first
-                ;; Since `&seq' must be first, we could check for it outside of
-                ;; processing, but we keep it with the other processing for
-                ;; consistency.
-                ('&seq             (cond
-                                    ((or is-seq whole-var pos-var opt-var rest-var key-var
-                                         allow-other-keys aux-var map-var)
-                                     (signal 'loopy-&seq-bad-position (list var-seq)))
-                                    ((seq-empty-p rest)
-                                     (signal 'loopy-bad-desctructuring
-                                             (list var-seq)))
-                                    (t
-                                     (stop-processing)
-                                     (setq is-seq t))))
-                ('&whole           (cond
-                                    ;; Make sure there is a variable named.
-                                    ((missing-after rest)
-                                     (signal 'loopy-&whole-missing (list var-seq)))
-                                    ;; Make sure `&whole' is before all else.
-                                    ((or whole-var pos-var opt-var rest-var key-var
-                                         allow-other-keys aux-var map-var)
-                                     (signal 'loopy-&whole-bad-position (list var-seq)))
-                                    (t
-                                     (stop-processing)
-                                     (setq processing-whole t))))
+           ((or '&rest '&body) (cond
+                                (dotted-rest-var
+                                 (signal 'loopy-&rest-dotted
+                                         (list var-seq)))
+                                ((missing-after rest)
+                                 (signal 'loopy-&rest-missing
+                                         (list var-seq)))
+                                ((and (> (seq-length rest) 1)
+                                      (let ((after-var (seq-elt rest 1)))
+                                        (not (memq after-var loopy--destructure-symbols))))
+                                 (signal 'loopy-&rest-multiple (list var-seq)))
+                                ;; In CL Lib, `&rest' must come before `&key',
+                                ;; but we decided to allow it to come after.
+                                ((or aux-var rest-var)
+                                 (signal 'loopy-&rest-bad-position
+                                         (list var-seq)))
+                                (t
+                                 (stop-processing)
+                                 (setq processing-rest t))))
 
-                ('&optional        (cond
-                                    ((missing-after rest)
-                                     (signal 'loopy-&optional-missing
-                                             (list var-seq)))
-                                    ;; Make sure `&optional' does not occur after
-                                    ;; `&rest'.
-                                    ((or opt-var rest-var key-var map-var aux-var)
-                                     (signal 'loopy-&optional-bad-position
-                                             (list var-seq)))
-                                    (t
-                                     (stop-processing)
-                                     (setq processing-opts t))))
+           ((or '&key '&keys) (cond
+                               ((not var-is-list)
+                                (signal 'loopy-&key-array
+                                        (list var-seq)))
+                               ((missing-after rest)
+                                (signal 'loopy-&key-missing
+                                        (list var-seq)))
+                               ((or aux-var key-var)
+                                (signal 'loopy-&key-bad-position
+                                        (list var-seq)))
+                               (t
+                                (stop-processing)
+                                (setq processing-keys t))))
 
-                ((or '&rest '&body) (cond
-                                     (dotted-rest-var
-                                      (signal 'loopy-&rest-dotted
-                                              (list var-seq)))
-                                     ((missing-after rest)
-                                      (signal 'loopy-&rest-missing
-                                              (list var-seq)))
-                                     ((and (> (seq-length rest) 1)
-                                           (let ((after-var (seq-elt rest 1)))
-                                             (not (memq after-var loopy--destructure-symbols))))
-                                      (signal 'loopy-&rest-multiple (list var-seq)))
-                                     ;; In CL Lib, `&rest' must come before `&key',
-                                     ;; but we decided to allow it to come after.
-                                     ((or aux-var rest-var)
-                                      (signal 'loopy-&rest-bad-position
-                                              (list var-seq)))
-                                     (t
-                                      (stop-processing)
-                                      (setq processing-rest t))))
+           ('&allow-other-keys (cond
+                                ((not var-is-list)
+                                 (signal 'loopy-&key-array
+                                         (list var-seq)))
+                                ((not processing-keys)
+                                 (signal 'loopy-&allow-other-keys-without-&key
+                                         (list var-seq)))
+                                (t
+                                 (stop-processing)
+                                 (setq allow-other-keys t))))
 
-                ((or '&key '&keys) (cond
-                                    ((not (eq type 'list))
-                                     (signal 'loopy-&key-array
-                                             (list var-seq)))
-                                    ((missing-after rest)
-                                     (signal 'loopy-&key-missing
-                                             (list var-seq)))
-                                    ((or aux-var key-var)
-                                     (signal 'loopy-&key-bad-position
-                                             (list var-seq)))
-                                    (t
-                                     (stop-processing)
-                                     (setq processing-keys t))))
+           ('&map             (cond
+                               ((missing-after rest)
+                                (signal 'loopy-&map-missing (list var-seq)))
+                               ((or aux-var map-var)
+                                (signal 'loopy-&map-bad-position
+                                        (list var-seq)))
+                               (t
+                                (stop-processing)
+                                (setq processing-maps t))))
 
-                ('&allow-other-keys (cond
-                                     ((not (eq type 'list))
-                                      (signal 'loopy-&key-array
-                                              (list var-seq)))
-                                     ((not processing-keys)
-                                      (signal 'loopy-&allow-other-keys-without-&key
-                                              (list var-seq)))
-                                     (t
-                                      (stop-processing)
-                                      (setq allow-other-keys t))))
+           ('&aux
+            (if (or (missing-after rest)
+                    aux-var)
+                (signal 'loopy-&aux-bad-position (list var-seq))
+              (stop-processing)
+              (setq processing-auxs t)))
 
-                ('&map             (cond
-                                    ((missing-after rest)
-                                     (signal 'loopy-&map-missing (list var-seq)))
-                                    ((or aux-var map-var)
-                                     (signal 'loopy-&map-bad-position
-                                             (list var-seq)))
-                                    (t
-                                     (stop-processing)
-                                     (setq processing-maps t))))
+           ('&environment
+            (signal 'loopy-bad-desctructuring (list var-seq)))
 
-                ('&aux
-                 (if (or (missing-after rest)
-                         aux-var)
-                     (signal 'loopy-&aux-bad-position (list var-seq))
-                   (stop-processing)
-                   (setq processing-auxs t)))
+           ((guard processing-whole)
+            (cond
+             ((loopy--var-ignored-p first)
+              (signal 'loopy-&whole-missing (list var-seq)))
+             (t
+              (setq whole-var first
+                    processing-whole nil))))
 
-                ('&environment
-                 (signal 'loopy-bad-desctructuring (list var-seq)))
+           ((guard processing-rest)
+            ;; `&rest' var can be ignored for clarity,
+            ;; but it is probably an error to ignore it
+            ;; when there are no positional or optional variables.
+            (if (and (loopy--var-ignored-p first)
+                     (null pos-var)
+                     (null opt-var))
+                (signal 'loopy-&rest-missing
+                        (list var-seq))
+              (setq rest-var first
+                    processing-rest nil)))
 
-                ((guard processing-whole)
-                 (cond
-                  ((loopy--var-ignored-p first)
-                   (signal 'loopy-&whole-missing (list var-seq)))
-                  (t
-                   (setq whole-var first
-                         processing-whole nil))))
+           ((guard processing-opts)
+            (if (and (consp first)
+                     (cdr first)
+                     (loopy--var-ignored-p (car first)))
+                (signal 'loopy-&optional-ignored-default-or-supplied
+                        (list var-seq))
+              (push first opt-var)))
 
-                ((guard processing-rest)
-                 ;; `&rest' var can be ignored for clarity,
-                 ;; but it is probably an error to ignore it
-                 ;; when there are no positional or optional variables.
-                 (if (and (loopy--var-ignored-p first)
-                          (null pos-var)
-                          (null opt-var))
-                     (signal 'loopy-&rest-missing
-                             (list var-seq))
-                   (setq rest-var first
-                         processing-rest nil)))
+           ((guard processing-keys)
+            (push first key-var))
 
-                ((guard processing-opts)
-                 (if (and (consp first)
-                          (cdr first)
-                          (loopy--var-ignored-p (car first)))
-                     (signal 'loopy-&optional-ignored-default-or-supplied
-                             (list var-seq))
-                   (push first opt-var)))
+           ((guard processing-maps)
+            (push first map-var))
 
-                ((guard processing-keys)
-                 (push first key-var))
+           ((guard processing-auxs)
+            (push first aux-var))
 
-                ((guard processing-maps)
-                 (push first map-var))
+           (_
+            (if (or opt-var rest-var key-var map-var aux-var
+                    allow-other-keys)
+                (signal 'loopy-bad-desctructuring (list var-seq))
+              (push first pos-var))))))
 
-                ((guard processing-auxs)
-                 (push first aux-var))
-
-                (_
-                 (if (or opt-var rest-var key-var map-var aux-var
-                         allow-other-keys)
-                     (signal 'loopy-bad-desctructuring (list var-seq))
-                   (push first pos-var)))))
-
-            (setq remaining-seq (seq-rest remaining-seq))))
-
-        (let ((val `((whole . ,whole-var)
-                     (pos . ,(nreverse pos-var))
-                     (opt . ,(nreverse opt-var))
-                     (rest . ,(or dotted-rest-var rest-var))
-                     (key . ,(nreverse key-var))
-                     (allow-other-keys . ,allow-other-keys)
-                     (map . ,(nreverse map-var))
-                     (aux . ,(nreverse aux-var))
-                     (seq . ,is-seq))))
-          (puthash var-seq val loopy--get-var-groups-cache)
-          val))))
+      (let ((val `((whole . ,whole-var)
+                   (pos . ,(nreverse pos-var))
+                   (opt . ,(nreverse opt-var))
+                   (rest . ,(or dotted-rest-var rest-var))
+                   (key . ,(nreverse key-var))
+                   (allow-other-keys . ,allow-other-keys)
+                   (map . ,(nreverse map-var))
+                   (aux . ,(nreverse aux-var))
+                   (seq . ,is-seq))))
+        val))))
 
 (defun loopy--get-&optional-spec (form)
   "Get the spec of the `&optional' variable FORM as (VAR DEFAULT SUPPLIED LEN)."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol)) cons)))
   (let ((var)
         (default)
         (supplied)
@@ -278,6 +282,8 @@ Type is one of `list' or `array'."
 
 (defun loopy--get-&key-spec (var-form)
   "Get the spec of `&key' VAR-FORM as (KEY VAR DEFAULT SUPPLIED)."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol)) cons)))
   (pcase-let (((or (or (seq (seq key var) default supplied)
                        (seq (seq key var) default)
                        (seq (seq key var)))
@@ -307,6 +313,8 @@ Type is one of `list' or `array'."
 
 (defun loopy--get-&map-spec (var-form)
   "Get the spec of `&map' VAR-FORM as (KEY VAR DEFAULT SUPPLIED)."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol)) cons)))
   (pcase-let (((or (seq key var default supplied)
                    (seq key var default)
                    (seq key var)
@@ -326,6 +334,8 @@ Type is one of `list' or `array'."
 
 (defun loopy--get-&aux-spec (var-form)
   "Get the spec of `&aux' VAR-FORM as (VAR VAL)."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol)) cons)))
   (pcase-let (((or (seq var val)
                    (seq var)
                    (and (pred symbolp)
@@ -337,6 +347,8 @@ Type is one of `list' or `array'."
 
 (defun loopy--get-var-list (var-seq)
   "Get the variables in VAR-SEQ as a flat, unordered list."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol)) cons)))
   (let ((groups (loopy--get-var-groups var-seq))
         (result nil))
     (cl-labels ((fn (val) (if (seqp val)
@@ -386,6 +398,9 @@ Type is one of `list' or `array'."
 
 FN is the function.  ARG2 is the argument to move to the second
 position of the call to FN in the pattern."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function ((function (t t) t) t) cons)))
   (static-if (>= emacs-major-version 30)
       `(,fn _ ,arg2)
     `(loopy--pcase-flip-1 ,fn ,arg2)))
@@ -396,6 +411,9 @@ position of the call to FN in the pattern."
 If VAR is ignored according to `loopy--var-ignored-p', return
 `_'.  Otherwise, if VAR is a sequence according to `seqp',
 return `(loopy VAR)'.  In all other cases, VAR is returned."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol))
+                            (or cons symbol))))
   (cond
    ((loopy--var-ignored-p var) '_)
    ((seqp var) `(loopy ,var))
@@ -404,6 +422,9 @@ return `(loopy VAR)'.  In all other cases, VAR is returned."
 ;; TODO: Use this in `list' pattern.
 (defun loopy--pcase-let-nil-list (pat)
   "Return a list of patterns binding variables in PAT to nil."
+  (declare (important-return-value t)
+           (ftype (function ((or sequence symbol))
+                            (or cons symbol))))
   ;; Need to quote `nil' for it to be a `pcase' pattern.
   (pcase pat
     (`(loopy ,(and (pred seqp) seq))
@@ -418,6 +439,9 @@ return `(loopy VAR)'.  In all other cases, VAR is returned."
 POS-VARS is the list of the positional variables.  OPT-VARS is the list of
 the optional variables.  REST-VAR is the `&rest' variable.
 MAP-OR-KEY-VARS is whether there are map or key variables."
+  (declare (important-return-value t)
+           (ftype (function (cons cons symbol boolean)
+                            cons)))
   ;; A modified version of the back-quote pattern to better work with
   ;; optional values.
   (cond
@@ -458,6 +482,9 @@ MAP-OR-KEY-VARS is whether there are map or key variables."
 POS-VARS is the list of the positional variables.  OPT-VARS is the list of
 the optional variables.  REST-VAR is the `&rest' variable.
 MAP-OR-KEY-VARS is whether there are map or key variables."
+  (declare (important-return-value t)
+           (ftype (function (cons cons symbol boolean)
+                            cons)))
   (let ((pos-len (length pos-vars))
         (opt-len (length opt-vars)))
     ;; We allow the variable form to be shorter than the
@@ -542,6 +569,8 @@ MAP-OR-KEY-VARS is whether there are map or key variables."
 
 (defun loopy--seq-length= (seq n)
   "Check whether the length of SEQ is equal to N."
+  (declare (important-return-value t)
+           (ftype (function (seq integer) boolean)))
   (cond
    ((sequencep seq)
     (length= seq n))
@@ -555,6 +584,8 @@ MAP-OR-KEY-VARS is whether there are map or key variables."
 
 (defun loopy--seq-length> (seq n)
   "Check whether the length of SEQ is greater than to N."
+  (declare (important-return-value t)
+           (ftype (function (seq integer) boolean)))
   (cond
    ((sequencep seq) (length> seq n))
    ;; Take advantage of lazy evaluation of streams.
@@ -572,6 +603,9 @@ destructured value.
 POS-VARS is the list of the positional variables.  OPT-VARS is the list of
 the optional variables.  REST-VAR is the `&rest' variable.
 MAP-OR-KEY-VARS is whether there are map or key variables."
+  (declare (important-return-value t)
+           (ftype (function (cons cons symbol boolean)
+                            cons)))
   (let ((pos-len (length pos-vars))
         (opt-len (length opt-vars)))
     (cl-labels ((make-pos-pats ()
@@ -665,6 +699,8 @@ MAP-OR-KEY-VARS is whether there are map or key variables."
 KEY-VARS are the forms of the key variables.  ALLOW-OTHER-KEYS is
 whether `&allow-other-keys' was used.  PLIST-VAR is the variable
 holding the property list."
+  (declare (important-return-value t)
+           (ftype (function (cons boolean) cons)))
   ;; If we aren't checking whether all keys in EXPVAL were given,
   ;; then we can use simpler patterns since we don't need to store the
   ;; value of the key.
@@ -750,6 +786,8 @@ holding the property list."
 
 (defun loopy--pcase-pat-&map-pattern (map-vars)
   "Build a `pcase' pattern for the `&map' variables MAP-VARS."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (let ((mapsym (gensym "map")))
     `(and (pred mapp)
           ,@(mapcar (lambda (var-form)
@@ -785,6 +823,8 @@ holding the property list."
   "Build `pcase' pattern for `&aux' variables.
 
 AUX-VARS is the list of bindings."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   `(and ,@(cl-loop
            for bind in aux-vars
            for (var val) = (loopy--get-&aux-spec bind)
@@ -877,6 +917,9 @@ See the Info node `(loopy)Basic Destructuring'."
 ;;;; Destructuring for Iteration and Accumulation Commands
 (defun loopy--pcase-make-erroring-branch (pattern)
   "Create a branch for `pcase-compile-patterns' that reports an error for PATTERN."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (t) cons)))
   ;; It looks like Pcase provides only a single variable matching the symbol
   ;; in VARVALS, but we use `alist-get' just to be sure.
   (cons 'loopy--pcase-unmatched
@@ -896,6 +939,13 @@ Returns a list.  The elements are:
 
 If ERROR is non-nil, then signal an error in the produced code if
 the pattern doesn't match."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function ((or symbol sequence) t (member :error) boolean)
+           ;;                      cons)
+           ;;            (function ((or symbol sequence) t)
+           ;;                      cons)))
+           )
   (if (symbolp var)
       (list `(setq ,var ,val)
             (list var))
@@ -927,6 +977,11 @@ Returns a list of two elements:
 2. A function to be called with the code to be wrapped, which
   should produce wrapped code appropriate for BINDINGS,
   such as a `let*' form."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (cons (member :error) boolean) cons)
+           ;;            (function (cons) cons)))
+           )
   (let ((new-bindings nil)
         (all-vars nil))
     (pcase-dolist (`(,var ,val) bindings)
@@ -969,6 +1024,11 @@ NAME is the name of the command.  VAR-OR-VAL is a variable name
 or, if using implicit variables, a value .  VAL is a value, and
 should only be used if VAR-OR-VAL is a variable.  ERROR is when
 an error should be signaled if the pattern doesn't match."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (or (function (cons (member :error) boolean) cons)
+           ;;            (function (cons) cons)))
+           )
   (let* ((instructions)
          (always-used-cases
           (cons var
@@ -1072,7 +1132,9 @@ an error should be signaled if the pattern doesn't match."
                                    ,(funcall msetter
                                              `(map-insert ,mgetter ,key ,v))
                                    ;; Always return the value.
-                                   ,v))))))))))
+                                   ,v)))))))))
+           (ftype (function (t t &optional t) t))
+           (important-return-value t))
   (inline-letevals (map key default)
     (inline-quote (map-elt ,map ,key ,default))))
 
@@ -1091,7 +1153,9 @@ an error should be signaled if the pattern doesn't match."
                                `(progn
                                   (setf (aref ,seq ,idx) ,v)
                                   ,(funcall setter seq)
-                                  ,v)))))))))
+                                  ,v))))))))
+           (ftype (function (array (integer 0 *)) t))
+           (important-return-value t))
   (inline-letevals (sequence idx)
     (inline-quote (aref ,sequence ,idx))))
 
@@ -1110,7 +1174,9 @@ an error should be signaled if the pattern doesn't match."
                                `(progn
                                   (setf (seq-elt ,seq ,idx) ,v)
                                   ,(funcall setter seq)
-                                  ,v)))))))))
+                                  ,v))))))))
+           (ftype (function (t (integer 0 *)) t))
+           (important-return-value t))
   (inline-letevals (sequence idx)
     (inline-quote (seq-elt ,sequence ,idx))))
 
@@ -1128,12 +1194,16 @@ an error should be signaled if the pattern doesn't match."
                                   ,(funcall setter
                                             `(loopy--destructure-seq-replace
                                               ,getter ,v ,n))
-                                  ,v)))))))))
+                                  ,v))))))))
+           (ftype (function (t (integer 0 *)) t))
+           (important-return-value t))
   (inline-letevals (sequence n)
     (inline-quote (seq-drop ,sequence ,n))))
 
 (cl-defgeneric loopy--destructure-seq-replace (sequence replacements start)
   "Replace elements of SEQUENCE from START with elements of REPLACEMENTS."
+  (declare (ftype (function (seq seq (integer 0 *)) seq))
+           (important-return-value t))
   ;; For a generic sequence, there doesn't seem to be a good way
   ;; to avoid calculating the length of the original sequence.
   (let ((len-old (seq-length sequence)))
@@ -1149,6 +1219,7 @@ an error should be signaled if the pattern doesn't match."
 
 (cl-defmethod loopy--destructure-seq-replace ((sequence array) replacements start)
   "Replace elements of SEQUENCE from START with elements of REPLACEMENTS."
+  ;; TODO: No `declare' form for `cl-defmethod'?
   (let ((len-old (length sequence)))
     (cl-block loop
       (seq-map-indexed (lambda (new-elt idx)
@@ -1161,6 +1232,7 @@ an error should be signaled if the pattern doesn't match."
 
 (cl-defmethod loopy--destructure-seq-replace ((sequence list) replacements start)
   "Replace elements of SEQUENCE from START with elements of REPLACEMENTS."
+  ;; TODO: No `declare' form for `cl-defmethod'?
   (let ((repped-seq (nthcdr start sequence)))
     (cl-block loop
       (seq-map (lambda (new-elt)
@@ -1192,7 +1264,9 @@ This definition might not be necessary, but we use it just in case."
                                `(progn
                                   ,(funcall setter
                                             `(cl-replace ,getter ,v :start1 ,n))
-                                  ,v)))))))))
+                                  ,v))))))))
+           (ftype (function (sequence (integer 0 *)) sequence))
+           (important-return-value t))
   (inline-letevals (sequence n)
     (inline-quote (cl-subseq ,sequence ,n))))
 
@@ -1331,6 +1405,8 @@ IDX to a large value for the super-list."
 VALUE-EXPRESSION should itself be a `setf'-able place.
 
 Returns a list of bindings suitable for `cl-symbol-macrolet'."
+  (declare (ftype (function ((or symbol sequence) t) cons))
+           (important-return-value t))
   (pcase var
     ((pred symbolp) (unless (loopy--var-ignored-p var)
                       `((,var ,value-expression))))
@@ -1354,6 +1430,8 @@ Returns a list of bindings suitable for `cl-symbol-macrolet'.
 - `&optional' is not supported.
 - `&map' references the values in the map.
 - `&key' references the values in the property list."
+  (declare (ftype (function (sequence t) cons))
+           (important-return-value t))
   (map-let (('whole whole-var)
             ('pos   pos-vars)
             ('opt   opt-vars)
@@ -1434,6 +1512,8 @@ Returns a list of bindings suitable for `cl-symbol-macrolet'.
 - `&map' references the values in the map.
 - `&key' references the values in the property list,
   which is an error for arrays."
+  (declare (ftype (function (array t) cons))
+           (important-return-value t))
   (map-let (('whole whole-var)
             ('pos   pos-vars)
             ('opt   opt-vars)
@@ -1500,6 +1580,8 @@ Returns a list of bindings suitable for `cl-symbol-macrolet'.
 
 (cl-defun loopy--destructure-generalized-list (var-form value-expression)
   "Destructure list VALUE-EXPRESSION with generalized variables via VAR-FORM."
+  (declare (ftype (function (cons t) cons))
+           (important-return-value t))
   (map-let (('whole whole-var)
             ('pos   pos-vars)
             ('opt   opt-vars)

--- a/lisp/loopy-iter.el
+++ b/lisp/loopy-iter.el
@@ -244,6 +244,9 @@ accumulated value.
 To avoid an infinite loop, this function replaces the `loopy--optimized-accum'
 in the expression with `loopy--optimized-accum-2', which is then processed
 during a second pass on the expanded code."
+  (declare (important-return-value t)
+           (side-effect-free nil) ; arbitrary macro expansion
+           (ftype (function (cons) cons)))
   (loopy (with (plist (cadr arg)))
          (cons (k v) plist :by #'cddr)
          (collect k)
@@ -276,6 +279,11 @@ need to be tweaked."
   "Parse the `at' command as (at &rest COMMANDS).
 
 These commands affect other loops higher up in the call list."
+  (declare (important-return-value t)
+           (side-effect-free nil) ; `loopy' uses global variables
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   (loopy--check-target-loop-name target-loop)
   ;; We need to capture all non-main-body instructions into a new `at'
   ;; instruction, so we just temporarily `let'-bind
@@ -302,6 +310,11 @@ These commands affect other loops higher up in the call list."
 
 ;;;; For parsing special macro arguments
 
+(defvar loopy-iter--bare-names-internal nil
+  "Internal value of `loopy-iter-bare-names' for overrides." )
+(defvar loopy-iter--keywords-internal nil
+  "Internal value of `loopy-iter-keywords' for overrides." )
+
 ;; TODO: Combine this with `loopy--def-special-processor'.
 (defmacro loopy-iter--def-special-processor (name &rest body)
   "Create a processor for the special macro argument NAME and its aliases.
@@ -325,6 +338,10 @@ Variables available:
 
 Returns BODY without the `%s' argument."
                 name name)
+       (declare (important-return-value t)
+                ;; Using `list' instead of `cons' becuase we allow it to be nil
+                ;; here.
+                (ftype (function (list) list)))
        (loopy
         (accum-opt matching-args new-body)
         (with (first-is-keyword nil))
@@ -354,6 +371,10 @@ Returns BODY without the `%s' argument."
 
 (defun loopy-iter--process-special-arg-loop-name (body)
   "Process BODY and the loop name listed therein."
+  (declare (important-return-value t)
+           ;; Using `list' instead of `cons' becuase we allow it to be nil
+           ;; here.
+           (ftype (function (list) list)))
   (let* ((names)
          (new-body))
     (dolist (arg body)
@@ -686,6 +707,11 @@ packages from different authors.  See the updated Info node
   "Parse the `loopy-iter' command as (loopy-iter &rest BODY).
 
 See the info node `(loopy)The loopy-iter Macro' for more."
+  (declare (important-return-value t)
+           (side-effect-free nil)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) cons))
+           )
   `((loopy--main-body ,(macroexpand `(loopy-iter ,@body)))))
 
 (puthash 'loopy-iter

--- a/lisp/loopy-misc.el
+++ b/lisp/loopy-misc.el
@@ -127,10 +127,14 @@
 
 (defun loopy--signal-bad-iter (used-name true-name)
   "Signal an error for USED-NAME that is really TRUE-NAME."
+  (declare (ftype (function (symbol symbol) t))
+           (important-return-value nil))
   (signal 'loopy-iteration-in-sub-level (list used-name true-name)))
 
 (defun loopy--signal-must-be-top-level (command-name)
   "Signal an error for COMMAND-NAME."
+  (declare (ftype (function (symbol) t))
+           (important-return-value nil))
   (user-error "Can't use \"%s\" in `loopy' outside top-level" command-name))
 
 ;;;;; Errors on Destructuring
@@ -312,15 +316,23 @@ keywords and variables are separate."
 
 
 ;;;; Loop Tag Names
-(defun loopy--produce-non-returning-exit-tag-name (&optional loop-name)
+(defun loopy--produce-non-returning-exit-tag-name (loop-name)
   "Produce a tag from LOOP-NAME."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (pure t)
+           (ftype (function ((or symbol null)) symbol)))
   (if loop-name
       (intern (format "loopy--%s-non-returning-exit-tag" loop-name))
     'loopy--non-returning-exit-tag))
 
 
-(defun loopy--produce-skip-tag-name (&optional loop-name)
+(defun loopy--produce-skip-tag-name (loop-name)
   "Produce a tag from LOOP-NAME."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (pure t)
+           (ftype (function ((or symbol null)) symbol)))
   (if loop-name
       (intern (format "loopy-%s-skip-tag"  loop-name))
     'loopy--skip-tag))
@@ -333,6 +345,9 @@ keywords and variables are separate."
 When a quoted argument is passed to a macro, it can appear
 as `(quote my-var)' or `(function my-func)' inside the body.  For
 expansion, we generally only want the actual symbol."
+  (declare (side-effect-free nil)
+           (important-return-value t)
+           (ftype (function ((or symbol cons)) symbol)))
   (pcase function-form
     ((or (pred symbolp) `(lambda ,_))           function-form)
     ;; This could be something like "(function (lambda () ...))".
@@ -348,6 +363,9 @@ When quoted symbols are passed to the macro, these can show up as
 \"(quote SYMBOL)\", where we only want SYMBOL.
 
 For functions, use `loopy--get-function-symbol'."
+  (declare (side-effect-free nil)
+           (important-return-value t)
+           (ftype (function ((or symbol cons)) symbol)))
   (pcase quoted-form
     ((pred symbolp) quoted-form)
     (`(quote ,form) form)
@@ -357,7 +375,9 @@ For functions, use `loopy--get-function-symbol'."
   "Whether FORM-OR-SYMBOL is quoted via `quote' or `function'.
 
 If not, then it is possible that FORM is a variable."
-
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function ((or symbol cons)) boolean)))
   (and (listp form-or-symbol)
        (= 2 (length form-or-symbol))
        (or (eq (car form-or-symbol) 'quote)
@@ -381,7 +401,13 @@ first and ELEMENT second."
   ;; `cl-member-if' with a custom predicate instead.
   ;;
   ;; The CLHS is wrong in how `adjoin' works.  See #170.
-  (declare (compiler-macro loopy--member-p-comp))
+  (declare (compiler-macro loopy--member-p-comp)
+           (side-effect-free nil) ; Can't know because of TEST.
+           (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons t &key (function (t t) boolean))
+           ;;                  boolean))
+           )
   (setq test (or test #'equal))
   (if key
       (cl-loop with test-val = (funcall key element)
@@ -400,6 +426,11 @@ first and ELEMENT second."
 FORM is the original use of the function.  LIST is the sequence
 in which ELEMENT is sought.  TEST compare the elements of LIST and ELEMENT.
 KEY transforms those elements and ELEMENT."
+  (declare (important-return-value t)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons t t &key (function (t t) boolean))
+           ;;                  boolean))
+           )
   (if key
       (cl-with-gensyms (test-val seq-val)
         `(cl-loop with ,test-val = (funcall ,key ,element)

--- a/lisp/loopy-vars.el
+++ b/lisp/loopy-vars.el
@@ -60,6 +60,10 @@ function in the variable `loopy--flag-settings'."
   :type '(repeat symbol))
 
 (defun loopy--defalias-1 (alias definition)
+  "Create ALIAS for DEFINITION."
+  (declare (side-effect-free nil) ; Modify parsers.
+           (important-return-value nil)
+           (ftype (function (symbol symbol) t)))
   (if (eq alias definition)
       (error "Can't alias name to itself: `%s' -> `%s'"
              alias definition)
@@ -96,11 +100,17 @@ function in the variable `loopy--flag-settings'."
   "Add alias ALIAS for loop command DEFINITION.
 
 Definition must exist.  Neither argument need be quoted."
+  (declare (side-effect-free nil) ; Modify parsers.
+           (important-return-value nil)
+           (ftype (function (symbol symbol) t)))
   `(loopy--defalias-1 (quote ,(loopy--get-quoted-symbol alias))
                       (quote ,(loopy--get-quoted-symbol definition))))
 
 (defun loopy--expression-parser-map-p (obj)
   "Return when OBJ has the correct data for `loopy-expression-parsers'."
+  (declare (side-effect-free t) ; Modify parsers.
+           (important-return-value t)
+           (ftype (function (t) boolean)))
   (and (mapp obj)
        (map-every-p (lambda (k v)
                       (and (symbolp k)
@@ -680,6 +690,10 @@ Generally, this is used with commands that produce lists, such as
 (defun loopy--get-accum-counts (loop var cmd-name)
   "Get the count of accumulation places for VAR in LOOP.
 CMD-NAME is used for signaling errors."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (symbol symbol symbol)
+                            (integer 0 *))))
   (or (map-nested-elt loopy--accumulation-places (list loop var))
       (signal 'loopy-missing-accum-counters (list cmd-name))))
 
@@ -755,6 +769,9 @@ This list is mainly fed to the macro `loopy--wrap-variables-around-body'."))
 Some iteration commands (e.g., `reduce') will change their behavior
 depending on whether the accumulation variable is given an initial
 value."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (symbol) boolean)))
   (or (memq var-name (car-safe loopy--with-vars))
       (memq var-name loopy--without-vars)))
 
@@ -766,6 +783,9 @@ The variable can exist in `loopy--iteration-vars',
 `set'), or `loopy--generalized-vars'.
 
 Re-initializing an iteration variable is an error."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (symbol) (or cons nil))))
   (or (cl-loop for (var val) in loopy--iteration-vars
                when (eq var var-name)
                return (cons 'iteration val))
@@ -786,6 +806,9 @@ This can happen when multiple loop commands refer to the same
 variable, or when a variable is introduced via `with'.
 
 See also `loopy--with-bound-p' and `loopy--command-bound-p'."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (symbol) boolean)))
   (or (loopy--with-bound-p var-name)
       (loopy--command-bound-p var-name)))
 
@@ -794,10 +817,16 @@ See also `loopy--with-bound-p' and `loopy--command-bound-p'."
 
 Accumulation commands can operate on the same variable, and we
   don't want that variable to appear more than once as an implied return."
+  (declare (side-effect-free t)
+           (important-return-value t)
+           (ftype (function (t) boolean)))
   (member expression loopy--implicit-return))
 
 (defun loopy--check-target-loop-name (target)
   "Signal an error whether TARGET is not a valid loop name."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function (symbol) t)))
   (unless (memq target loopy--known-loop-names)
     (signal 'loopy-unknown-loop-target (list target))))
 
@@ -811,10 +840,17 @@ Accepted places are the quoted symbols `start' or `end'.  The place
 
 For example, the `collect' command can add items at the beginning or end
 of a sequence."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function (symbol) t)))
   (unless (member pos '(start end))
     (signal 'loopy-bad-position-command-argument (list pos))))
 
 (defun loopy--normalize-position-name (pos)
+  "Normalize POS to standard values."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function (symbol) (member start end))))
   (pcase pos
     ((or 'beginning '(quote beginning) 'start '(quote start))
      'start)
@@ -831,6 +867,9 @@ of a sequence."
 
 (defun loopy--apply-flag (flag)
   "Apply the effects of the FLAG."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function (symbol) t)))
   (if-let* ((func (map-elt loopy--flag-settings flag)))
       (funcall func)
     (error "Loopy: Flag not defined: %s" flag)))

--- a/lisp/loopy.el
+++ b/lisp/loopy.el
@@ -138,6 +138,9 @@
 ;; It doesn't make sense to allow the disabling of this one.
 (defun loopy--enable-flag-default ()
   "Set `loopy' behavior back to its default state for the loop."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function () t)))
   (setq loopy--destructuring-for-with-vars-function
         #'loopy--destructure-for-with-vars-default
         loopy--destructuring-accumulation-parser
@@ -149,10 +152,16 @@
 ;;;;;; No-Loop
 (defun loopy--enable-flag-no-loop ()
   "Set `loopy--no-loop' to `t'."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function () t)))
   (setq loopy--no-loop t))
 
 (defun loopy--disable-flag-no-loop ()
   "Set `loopy--no-loop' to `nil'."
+  (declare (side-effect-free nil)
+           (important-return-value nil)
+           (ftype (function () t)))
   (setq loopy--no-loop nil))
 
 (cl-callf map-insert loopy--flag-settings 'no-loop #'loopy--enable-flag-no-loop)
@@ -165,6 +174,8 @@
 
 BINDING should be a list of two elements.  To avoid mistakes,
 this means that an explicit \"nil\" is always required."
+  (declare (important-return-value nil)
+           (ftype (function (t) nil)))
   (unless (and (consp binding)
                (= 2 (length binding)))
     (error "Invalid binding in `loopy' expansion: %s" binding)))
@@ -180,6 +191,8 @@ two elements:
 2. A function to be called with the code to be wrapped, which
   should produce wrapped code appropriate for BINDINGS,
   such as a `let*' form."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (funcall (or loopy--destructuring-for-with-vars-function
                #'loopy--destructure-for-with-vars-default)
            bindings))
@@ -192,6 +205,8 @@ Returns a list of two elements:
 2. A function to be called with the code to be wrapped, which
   should produce wrapped code appropriate for BINDINGS,
   such as a `let*' form."
+  (declare (important-return-value t)
+           (ftype (function (cons) cons)))
   (loopy--pcase-destructure-for-with-vars (cl-loop for b in bindings
                                                    for (var val) = b
                                                    collect (if (symbolp var)
@@ -204,7 +219,13 @@ Returns a list of two elements:
   "Create the loop body according to the variables found in `loopy--variables'.
 
 The function creates quoted code that should be used by a macro."
-
+  (declare
+   ;; All processing should have happened by this point.
+   (side-effect-free t)
+   ;; Uses dynamic variables.
+   (pure nil)
+   (important-return-value t)
+   (ftype (function () cons)))
 
   ;; Construct the expanded code from the inside out.  The result should work
   ;; something like the below code.  Unlike below, constructs are only used
@@ -455,6 +476,10 @@ Variables available:
 
 Returns BODY without the `%s' argument."
               name name)
+     (declare (important-return-value t)
+              (side-effect-free nil)
+              ;; Using `list' instead of `cons' so that it can be nil.
+              (ftype (function (list) list)))
      (let* ((matching-args (cl-remove-if (lambda (x)
                                            ;; If symbol, then is the loop name,
                                            ;; which is handled by a separate
@@ -481,6 +506,10 @@ Returns BODY without the `%s' argument."
 
 (defun loopy--process-special-arg-loop-name (body)
   "Process BODY and the loop name listed therein."
+  (declare (important-return-value t)
+           (side-effect-free nil)
+           ;; Using `list' instead of `cons' so that it can be nil.
+           (ftype (function (list) list)))
   (let ((names)
         (new-body))
     (dolist (arg body)
@@ -593,6 +622,9 @@ Returns BODY without the `%s' argument."
 
 Some variables can't simply be `let'-bound around the expansion
 code and must instead be cleaned up manually."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           (ftype (function () t)))
   (pop loopy--known-loop-names)
   (pop loopy--accumulation-places)
   (cl-callf map-delete loopy--at-instructions loopy--loop-name)
@@ -603,6 +635,9 @@ code and must instead be cleaned up manually."
 
 (defmacro loopy--with-protected-stack (&rest body)
   "Protect the stack variables from BODY during unwind and cleanup."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           (ftype (function (&rest t) t)))
   `(unwind-protect
        ,(macroexp-progn body)
      (loopy--clean-up-stack-vars)))
@@ -617,6 +652,11 @@ In `loopy', processing instructions is stateful.  This function
 merely pushes values into the correct variables.  The proper
 ordering of those variables is handled elsewhere, such as in the
 macro `loopy' itself."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) t))
+           )
   ;; Do it this way instead of with `set', cause was getting errors
   ;; about void variables.
   (let ((instruction-type (cl-first instruction))
@@ -739,6 +779,11 @@ macro `loopy' itself."
 If any instruction is in ERRORING-INSTRUCTIONS, then an error is raised.
 
 In `loopy', processing instructions is stateful."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) t))
+           )
   (dolist (instruction instructions)
     (when (memq (cl-first instruction) erroring-instructions)
       (error "Attempted to process should-error instruction: %s"
@@ -853,6 +898,11 @@ In `loopy', processing instructions is stateful."
 - Make `loopy--implicit-return' a list value if needed.
 
 When EXCLUDE-MAIN-BODY is non-nil, don't reverse `loopy--main-body'."
+  (declare (important-return-value nil)
+           (side-effect-free nil)
+           ;; TODO: `ftype' for `cl-defun'
+           ;; (ftype (function (cons) t))
+           )
   (unless exclude-main-body
     (setq loopy--main-body (nreverse loopy--main-body)))
   (setq loopy--iteration-vars (nreverse loopy--iteration-vars)


### PR DESCRIPTION
- Add `ftype`to function written using `defun`, but not to functions written
  using `cl-defun`.

- Add `imporant-return-value` to most functions we define.  Function which check
  for errors or which are for updating dynamic variables (found accumulation
  targets, the list of loop names, etc.) do not have that property.

- Add `side-effect-free` to a few functions.  Due to how Loopy can be
  extended (arbitrary commands and destructuring) and Loopy's current reliance
  on statefulness, we can only guarantee that a few functions are side-effect
  free. Besides, the Emacs Lisp manual states that this property tells the byte
  compiler that calls with ignored return values can be ignored, which is at
  odds with most of our functions having an `imporant-return-value`.

- Add `pure` to very few functions.  The limitations of adding
  `side-effect-free` also apply to adding `pure`.

- Update functions to simplify adding properties and making guarantees.  This is
  generally just simplifying call signatures to how we actually use the
  functions.  We also fix a few problems to fix byte compiler warnings.
  - Remove optional argument from `loopy--produce-non-returning-exit-tag-name`
    - Mark as `pure`.
  - Remove optional argument from `loopy--produce-skip-tag-name`
    - Mark as `pure`.
  - Remove optional argument from `loopy--update-accum-place-count`.
    - Note that updating place counts is not side effect free.
  - Check loop name in `loopy--parse-return-from-command`.
  - Move definition of `loopy-iter--bare-names-internal` and
    `loopy-iter--keywords-internal` to earlier in the file to avoid
    byte-compilation warnings.
  - Update Makefile.  Add Make targets for native-compiling files.
  - Fix definition of `loopy--update-accum-place-count`.
  - Make `loopy--get-var-groups` less generic and side-effect free.
    - Instead of using `seq` functions, always convert to a list.  This
      seems to be faster.
    - Remove `loopy--get-var-groups-cache` to make function side-effect free.
    - Mark as `pure`.